### PR TITLE
Display toast if description of new item is not entered

### DIFF
--- a/src/com/peacecorps/malaria/TripIndicatorPackingActivity.java
+++ b/src/com/peacecorps/malaria/TripIndicatorPackingActivity.java
@@ -7,6 +7,7 @@ import android.content.Context;
 import android.content.Intent;
 import android.database.Cursor;
 import android.os.Bundle;
+import android.util.Log;
 import android.util.SparseBooleanArray;
 import android.view.View;
 import android.widget.AdapterView;
@@ -29,7 +30,7 @@ public class TripIndicatorPackingActivity extends Activity {
     private long mNumDrugs=0;
     TextView numDrugs;
     ListView listView;
-    EditText cash;
+    EditText cash,edit;
     TextView whichDrug;
     public static String tripDrugName;
 
@@ -71,6 +72,9 @@ public class TripIndicatorPackingActivity extends Activity {
         /** List View **/
         listView = (ListView)findViewById(R.id.listV);
 
+        /**Description of the new item added**/
+        edit = (EditText) findViewById(R.id.packing_et);
+
         /**Populating the List **/
         Cursor cursor = sqLite.getPackingItem();
         String item="";
@@ -101,11 +105,20 @@ public class TripIndicatorPackingActivity extends Activity {
         View.OnClickListener listenerAdd = new View.OnClickListener() {
             @Override
             public void onClick(View v) {
-                EditText edit = (EditText) findViewById(R.id.packing_et);
-                list.add(edit.getText().toString());
-                sqLite.insertPackingItem(edit.getText().toString(),1,"no");
-                edit.setText("");
-                adapter.notifyDataSetChanged();
+                String s=edit.getText().toString();
+                if(s.equals(""))
+                {
+                    Toast.makeText(getApplicationContext(), "Enter item name ", Toast.LENGTH_SHORT).show();
+
+                }
+                else
+                {
+                    list.add(edit.getText().toString());
+                    sqLite.insertPackingItem(edit.getText().toString(),1,"no");
+                    edit.setText("");
+                    adapter.notifyDataSetChanged();
+
+                }
             }
         };
 


### PR DESCRIPTION
Earlier if we clicked on the plus button without entering anything in the edit text it created an item with no name , which could create confusing messages in remainder. Now if the edit text is left blank, field would not be added and a toast will tell the user to enter the item name.