### PR TITLE
changed keypad type of cash_et edittext to numeric

### DIFF
--- a/res/layout/trip_indicator_packing_dialog.xml
+++ b/res/layout/trip_indicator_packing_dialog.xml
@@ -112,6 +112,7 @@
             android:layout_marginEnd="20dp"
             android:layout_marginTop="10dp"
             android:padding="5dp"
+            android:inputType="number"
             android:layout_marginRight="5dp"
             android:layout_alignParentRight="true"
             android:background="@drawable/info_hub_button" />


### PR DESCRIPTION
The amount of cash entered by the user for the trip remainder is in numbers. So I changed the keypad type of cash_et edit text from text to numeric.