### PR TITLE
changed adherence level to N.A from 0% where required

### DIFF
--- a/src/com/peacecorps/malaria/SecondAnalyticFragment.java
+++ b/src/com/peacecorps/malaria/SecondAnalyticFragment.java
@@ -59,7 +59,7 @@ public class SecondAnalyticFragment extends Fragment {
         //Declaring the Views
         rootView = inflater.inflate(R.layout.fragment_second_analytic_screen,
                 null);
-
+        Log.e("MyTag", "Error message with my own tag");
         mSettingsButton = (Button) rootView.findViewById(R.id.fragment_second_screen_settings_button);
 
         firstMonthProgressLabel = (TextView) rootView.findViewById(R.id.firstMonthProgressLabel);
@@ -204,6 +204,9 @@ public class SecondAnalyticFragment extends Fragment {
     public void updateProgressBar(String choice, int date) {
         DatabaseSQLiteHelper sqLH = new DatabaseSQLiteHelper(getActivity());
         Typeface cf = Typeface.createFromAsset(getActivity().getAssets(),"fonts/garreg.ttf");
+        int SetupMonth= mSharedPreferenceStore.mPrefsStore.getInt("com.peacecorps.malaria.SetupMonth",-1);
+        int SetupYear= mSharedPreferenceStore.mPrefsStore.getInt("com.peacecorps.malaria.SetupYear",-1);
+        Log.d("setupYear/myear ",Integer.toString(SetupYear) +" " +Integer.toString(myear));
         firstMonthProgressLabel.setText(getMonth(date - 3));
         firstMonthProgressLabel.setTypeface(cf);
         int progress = sqLH.getData(mdate, myear, choice);
@@ -220,7 +223,11 @@ public class SecondAnalyticFragment extends Fragment {
 
         }
         firstMonthProgressBar.setProgress((int) progressp);
-        firstMonthProgressPercent.setText("" + (int) progressp + "%");
+        if((date-3)>=SetupMonth || myear!=SetupYear || (int)progressp!=0)
+            firstMonthProgressPercent.setText("" + (int) progressp + "%");
+        else
+            firstMonthProgressPercent.setText("N.A");
+
         firstMonthProgressPercent.setTypeface(cf);
 
         secondMonthProgressLabel.setText(getMonth(date - 2));
@@ -238,7 +245,11 @@ public class SecondAnalyticFragment extends Fragment {
 
         }
         secondMonthProgressBar.setProgress((int) progressp);
-        secondMonthProgressPercent.setText("" + (int) progressp + "%");
+        if((date-2)>=SetupMonth || myear!=SetupYear || (int)progressp!=0)
+            secondMonthProgressPercent.setText("" + (int) progressp + "%");
+        else
+            secondMonthProgressPercent.setText("N.A");
+
         secondMonthProgressPercent.setTypeface(cf);
 
         thirdMonthProgressLabel.setText(getMonth(date - 1));
@@ -254,7 +265,10 @@ public class SecondAnalyticFragment extends Fragment {
             thirdMonthProgressBar.setProgressDrawable(getResources().getDrawable(R.drawable.saf_progress_bar_green));
         }
             thirdMonthProgressBar.setProgress((int) progressp);
+        if((date-1)>=SetupMonth || myear!=SetupYear || (int)progressp!=0)
             thirdMonthProgressPercent.setText("" + (int) progressp + "%");
+        else
+            thirdMonthProgressPercent.setText("N.A");
         thirdMonthProgressPercent.setTypeface(cf);
 
         fourthMonthProgressLabel.setText(getMonth(date));
@@ -314,7 +328,7 @@ public class SecondAnalyticFragment extends Fragment {
         lineGraphView.getGraphViewStyle().setTextSize(8.0F);
         lineGraphView.setVerticalLabels(verLabels);
 
-        lineGraphView.setTitle("Adherence Rate vs Day");
+        lineGraphView.setTitle("Adherence Rate vs DayWise");
 
 
         lineGraphView.setScrollable(true);

--- a/src/com/peacecorps/malaria/UserMedicineSettingsFragmentActivity.java
+++ b/src/com/peacecorps/malaria/UserMedicineSettingsFragmentActivity.java
@@ -208,6 +208,8 @@ public class UserMedicineSettingsFragmentActivity extends FragmentActivity
 
             int hour = mCalendar.get(Calendar.HOUR_OF_DAY);
             int minute = mCalendar.get(Calendar.MINUTE);
+            int month= mCalendar.get(Calendar.MONTH);
+            Log.d("Month",Integer.toString(month));
 
             TimePickerDialog view = new TimePickerDialog(getActivity(), R.style.MyTimePicker ,this, hour, minute,
                     DateFormat.is24HourFormat(getActivity()));
@@ -260,11 +262,16 @@ public class UserMedicineSettingsFragmentActivity extends FragmentActivity
     public static void saveUserTimeAndMedicationPrefs() {
 
         int checkDay = mCalendar.get(Calendar.DAY_OF_WEEK);
-
+        int month= mCalendar.get(Calendar.MONTH);
+        int year = mCalendar.get(Calendar.YEAR);
 
         mSharedPreferenceStore.mEditor.putInt("com.peacecorps.malaria.AlarmHour", mHour)
                 .commit();
         mSharedPreferenceStore.mEditor.putInt("com.peacecorps.malaria.AlarmMinute", mMinute)
+                .commit();
+        mSharedPreferenceStore.mEditor.putInt("com.peacecorps.malaria.SetupMonth", month)
+                .commit();
+        mSharedPreferenceStore.mEditor.putInt("com.peacecorps.malaria.SetupYear", year)
                 .commit();
         mSharedPreferenceStore.mEditor.putInt("com.peacecorps.malaria.dayTakingDrug", checkDay);
 
@@ -275,6 +282,10 @@ public class UserMedicineSettingsFragmentActivity extends FragmentActivity
         mSharedPreferenceStore.mEditor.commit();
         mFragmentContext.startService(new Intent(mFragmentContext,
                 AlarmService.class));
+
+        int check=mSharedPreferenceStore.mPrefsStore.getInt("com.peacecorps.malaria.SetupYear",-1);
+        //int ah=mSharedPreferenceStore.mPrefsStore.getInt("com.peacecorps.malaria.AlarmHour",-1);
+        Log.d("check year",Integer.toString(check));
 
     }
 


### PR DESCRIPTION
Earlier the screen showed adherence percentage of last 4 months. So for a users who has started the medication just 2 months before, will get 0%  for the first 2 months and then his actual adherence for the next 2 months. Since, adherence is (# of doses taken)/(# of doses that should have been taken)  so adherence must be zero only if a person takes no medicine in the entire month during his medication tenure. So, now  we display 'N.A' instead of 0% for the months not falling under the medication tenure.
This is done by storing the month in the userMedicineSettingFragmentActivity in shared preference and then comparing it with the current date. If the user specifically goes to a date before the starting date and changes then it dislays the adherence accordingly.