### PR TITLE
Edit button disabled and background grayed for future dates

### DIFF
--- a/res/drawable/roundedbutton_grey.xml
+++ b/res/drawable/roundedbutton_grey.xml
@@ -1,0 +1,37 @@
+<?xml version="1.0" encoding="utf-8"?>
+
+<shape
+    xmlns:android="http://schemas.android.com/apk/res/android"
+    android:shape="rectangle"
+    >
+
+    <!-- view background color -->
+    <solid
+        android:color="@color/gray" >
+    </solid>
+
+    <!-- view border color and width -->
+    <stroke
+        android:width="3dp"
+        android:color="@color/white" >
+    </stroke>
+
+    <!-- If you want to add some padding -->
+    <padding
+        android:left="4dp"
+        android:top="4dp"
+        android:right="4dp"
+        android:bottom="4dp"    >
+    </padding>
+
+    <!-- Here is the corner radius -->
+    <corners
+        android:topLeftRadius="30dp"
+        android:topRightRadius="30dp"
+        android:bottomLeftRadius="30dp"
+        android:bottomRightRadius="30dp">
+    </corners>
+
+
+
+</shape>

--- a/src/com/peacecorps/malaria/DayFragmentActivity.java
+++ b/src/com/peacecorps/malaria/DayFragmentActivity.java
@@ -63,6 +63,9 @@ public class DayFragmentActivity extends FragmentActivity {
         /*defining variables for accessing Database*/
         sqLite= new DatabaseSQLiteHelper(this);
 
+        ImageButton btnChangeData = (ImageButton)findViewById(R.id.btnChangeData);
+        final ImageView indicator = (ImageView)findViewById(R.id.medi_indicator);
+
         /*displaying clicked date on the Day Fragment*/
         Intent intent = getIntent();
         String selected_date = intent.getStringExtra(ThirdAnalyticFragment.DATE_TAG);
@@ -109,70 +112,8 @@ public class DayFragmentActivity extends FragmentActivity {
         String data=sqLite.getMedicationData(day, month, year);
         Log.d(TAGD, "++++++" + data + "++++++");
 
-        /*Setting the Indicator according to the Result*/
-        final ImageView indicator = (ImageView)findViewById(R.id.medi_indicator);
-        if(data.compareTo("yes")==0)
-        {
-            Toast.makeText(getApplicationContext(),"I took medicine!",Toast.LENGTH_LONG).show();
-            indicator.setBackgroundResource(R.drawable.accept_medi_checked_);
-        }
-        else if(data.compareTo("no")==0) {
-            indicator.setBackgroundResource(R.drawable.reject_medi_checked);
-            Toast.makeText(getApplicationContext(), "I didn't take medicine!", Toast.LENGTH_LONG).show();
-        }
-        else
-        {   Log.d(TAGD,"Inside Missed Drug Entry");
-
-            selected_date=SharedPreferenceStore.mPrefsStore.getString("com.peacecorps.malaria.checkMediLastTakenTime","");
-            SimpleDateFormat dateF = new SimpleDateFormat("dd/MM");
-            Date cd=Calendar.getInstance().getTime();
-            try {
-                cd   = dateF.parse(selected_date);
-            } catch (Exception e) {
-                e.printStackTrace();
-            }
-            cal.setTime(cd);
-
-            Log.d(TAGD,"Medication Last Taken Time");
-            Log.d(TAGD, "" + cal.get(Calendar.DATE));
-            Log.d(TAGD, "" + cal.get(Calendar.MONTH));
-            Log.d(TAGD, "" + cal.get(Calendar.YEAR));
-
-            long queried_date=comp_date.getTime();
-            long last_medication_date = cd.getTime();
-
-            Calendar c= Calendar.getInstance();
-            long current_date= c.getTimeInMillis();
-
-
-            if(queried_date>=firstTime)
-            {
-                if(queried_date<=current_date)
-                {
-                    Toast.makeText(getApplicationContext(), "I missed entering medicine!", Toast.LENGTH_LONG).show();
-                    sqLite.insertOrUpdateMissedMedicationEntry(day, month, year, 0);
-                }
-                else
-                {
-                    Toast.makeText(getApplicationContext(), "This is a future date, you cannot edit it!", Toast.LENGTH_LONG).show();
-                    flag=1;
-                }
-            }
-            else {
-                //Toast.makeText(getApplicationContext(), "This is a date before medication even started, you can't edit it!", Toast.LENGTH_LONG).show();
-                Toast.makeText(getApplicationContext(), "I missed entering medicine!", Toast.LENGTH_LONG).show();
-                sqLite.insertOrUpdateMissedMedicationEntry(day, month, year, 0);
-
-            }
-
-
-
-
-
-        }
 
         /*Implementing Editing Data Button for a Day Page*/
-        ImageButton btnChangeData = (ImageButton)findViewById(R.id.btnChangeData);
         btnChangeData.setOnClickListener(new View.OnClickListener() {
             @Override
             public void onClick(View v) {
@@ -281,6 +222,73 @@ public class DayFragmentActivity extends FragmentActivity {
 
             }
         });
+
+        /*Setting the Indicator according to the Result*/
+
+        if(data.compareTo("yes")==0)
+        {
+            Toast.makeText(getApplicationContext(),"I took medicine!",Toast.LENGTH_LONG).show();
+            indicator.setBackgroundResource(R.drawable.accept_medi_checked_);
+        }
+        else if(data.compareTo("no")==0) {
+            indicator.setBackgroundResource(R.drawable.reject_medi_checked);
+            Toast.makeText(getApplicationContext(), "I didn't take medicine!", Toast.LENGTH_LONG).show();
+        }
+        else
+        {   Log.d(TAGD,"Inside Missed Drug Entry");
+
+            selected_date=SharedPreferenceStore.mPrefsStore.getString("com.peacecorps.malaria.checkMediLastTakenTime","");
+            SimpleDateFormat dateF = new SimpleDateFormat("dd/MM");
+            Date cd=Calendar.getInstance().getTime();
+            try {
+                cd   = dateF.parse(selected_date);
+            } catch (Exception e) {
+                e.printStackTrace();
+            }
+            cal.setTime(cd);
+
+            Log.d(TAGD,"Medication Last Taken Time");
+            Log.d(TAGD, "" + cal.get(Calendar.DATE));
+            Log.d(TAGD, "" + cal.get(Calendar.MONTH));
+            Log.d(TAGD, "" + cal.get(Calendar.YEAR));
+
+            long queried_date=comp_date.getTime();
+            long last_medication_date = cd.getTime();
+
+            Calendar c= Calendar.getInstance();
+            long current_date= c.getTimeInMillis();
+
+
+            if(queried_date>=firstTime)
+            {
+                if(queried_date<=current_date)
+                {
+                    Toast.makeText(getApplicationContext(), "I missed entering medicine!", Toast.LENGTH_LONG).show();
+                    sqLite.insertOrUpdateMissedMedicationEntry(day, month, year, 0);
+                }
+                else
+                {
+                    Toast.makeText(getApplicationContext(), "This is a future date, you cannot edit it!", Toast.LENGTH_LONG).show();
+                    btnChangeData.setBackgroundResource(R.drawable.roundedbutton_grey);
+                    btnChangeData.setClickable(false);
+                    flag=1;
+                }
+            }
+            else {
+                //Toast.makeText(getApplicationContext(), "This is a date before medication even started, you can't edit it!", Toast.LENGTH_LONG).show();
+                Toast.makeText(getApplicationContext(), "I missed entering medicine!", Toast.LENGTH_LONG).show();
+                sqLite.insertOrUpdateMissedMedicationEntry(day, month, year, 0);
+
+            }
+
+
+
+
+
+        }
+
+
+
     }
 
     /**Computing the Adherence Rate for selected Date**/


### PR DESCRIPTION
Earlier In the thirdAnalyticFragment if we clicked on a future date it displayed a message "This is a future date you cannit edit it ". But the edit button was still clickable and on clicking, it displayed a fragment with option to change data.
Now for future dates , the edit button is disabled (clicking it will have no effect) and its color also gets changed to gray to maintain consistency with the UI. Here is what it looks like for future date.
![screenshot_2015-11-09-02-44-56](https://cloud.githubusercontent.com/assets/8321130/11017403/e5ccc570-85c3-11e5-824a-55003cea86bf.png)

