### PR TITLE
Fixed app crashing on TripIndicatorFragmentActivity

### DIFF
--- a/src/com/peacecorps/malaria/TripIndicatorFragmentActivity.java
+++ b/src/com/peacecorps/malaria/TripIndicatorFragmentActivity.java
@@ -329,17 +329,24 @@ public class TripIndicatorFragmentActivity extends FragmentActivity {
             @Override
             public void onClick(View v) {
 
-                Intent intent = new Intent(getApplication(), TripIndicatorPackingActivity.class);
+                  if(departureMonth.getText().toString().equals("") || arrivalMonth.getText().toString().equals("") )
+                {
+                    Toast.makeText(getApplicationContext(),"Enter Departure Date and Arrival Date First ",Toast.LENGTH_SHORT).show();
+                }
+               else
+                {
+                    Intent intent = new Intent(getApplication(), TripIndicatorPackingActivity.class);
 
-                Log.d(TAGTIFA,departure_formattedate+"  "+arrival_formattedate);
+                    Log.d(TAGTIFA,departure_formattedate+"  "+arrival_formattedate);
 
-                setNumDrugs(departure_formattedate, arrival_formattedate);
+                    setNumDrugs(departure_formattedate, arrival_formattedate);
 
-                intent.putExtra(DRUG_TAG, num_drugs);
+                    intent.putExtra(DRUG_TAG, num_drugs);
 
-                startActivity(intent);
+                    startActivity(intent);
 
-                packingSelect.setText(TripIndicatorPackingActivity.tripDrugName);
+                    packingSelect.setText(TripIndicatorPackingActivity.tripDrugName);
+                }
             }
         });
 


### PR DESCRIPTION
The app was crashing on the TripIndicatorFragmentActivity if the packing list was clicked before entering departure date and arrival date because both dates are used are parameters to a function which is called on clicking ' packing list '.

Now the user gets a toast message to first enter the arrival and departure date, if he clicks the packing list before entering them. Thus the application does not crash.