### PR TITLE
Correct no. drugs calculated for trip on TripIndicatorFragmentActivity

### DIFF
--- a/res/layout/trip_indicator_packing_dialog.xml
+++ b/res/layout/trip_indicator_packing_dialog.xml
@@ -112,6 +112,7 @@
             android:layout_marginEnd="20dp"
             android:layout_marginTop="10dp"
             android:padding="5dp"
+            android:inputType="number"
             android:layout_marginRight="5dp"
             android:layout_alignParentRight="true"
             android:background="@drawable/info_hub_button" />

--- a/res/layout/trip_indicator_packing_dialog.xml
+++ b/res/layout/trip_indicator_packing_dialog.xml
@@ -64,7 +64,7 @@
                 android:layout_height="40dp"
                 android:background="@drawable/info_hub_button"
                 android:textColor="@color/white"
-                android:textSize="20dp"
+                android:textSize="15dp"
                 android:textStyle="bold"
                 android:layout_alignParentRight="true"
                 android:layout_alignParentEnd="true"

--- a/src/com/peacecorps/malaria/TripIndicatorFragmentActivity.java
+++ b/src/com/peacecorps/malaria/TripIndicatorFragmentActivity.java
@@ -62,7 +62,7 @@ public class TripIndicatorFragmentActivity extends FragmentActivity {
     static SharedPreferenceStore mSharedPreferenceStore;
     private Dialog dialog = null;
     private ImageView loc_history;
-    public static TextView packingSelect;
+    public static TextView packingSelect,departureMonth,arrivalMonth;
     public static final String DRUG_TAG="com.peacecorps.malaria.TripIndicatorFragmentActivity.DRUG_TAG";
     long num_drugs=0;
     private String arrival_formattedate, departure_formattedate;
@@ -104,6 +104,8 @@ public class TripIndicatorFragmentActivity extends FragmentActivity {
         alarmManager = (AlarmManager)getSystemService(ALARM_SERVICE);
         tripTime = (TextView)findViewById(R.id.trip_time);
         pmtLabel = (TextView)findViewById(R.id.pmt);
+        departureMonth=(TextView)findViewById(R.id.trip_month_departure);
+        arrivalMonth=(TextView)findViewById(R.id.trip_month);
 
         //setting fonts
         Typeface cf = Typeface.createFromAsset(getAssets(),"fonts/garreg.ttf");
@@ -213,91 +215,114 @@ public class TripIndicatorFragmentActivity extends FragmentActivity {
                 /*Bundle b = getIntent().getExtras();
                 String[] resultArr = b.getStringArray("selectedItems");*/
 
-                String chklist="",item="";
-                int q=0;
+               if(locationSpinner.getText().toString().equals(""))
+               {
+                   Toast.makeText(getApplicationContext()," Location Missing ",Toast.LENGTH_SHORT).show();
+               }
+               else if(tripTime.getText().toString().equals(""))
+               {
+                   Toast.makeText(getApplicationContext()," Remainder Time Missing ",Toast.LENGTH_SHORT).show();
+               }
+               else if(packingSelect.getText().toString().equals(""))
+               {
+                   Toast.makeText(getApplicationContext()," Packing List Missing ",Toast.LENGTH_SHORT).show();
+               }
+               else if(departureMonth.getText().toString().equals(""))
+               {
+                   Toast.makeText(getApplicationContext()," Departure Date Missing ",Toast.LENGTH_SHORT).show();
+               }
+               else if(arrivalMonth.getText().toString().equals(""))
+               {
+                   Toast.makeText(getApplicationContext()," Arrival Date Missing ",Toast.LENGTH_SHORT).show();
+               }
+                else
+               {
+                   String chklist="",item="";
+                   int q=0;
 
                /* for(int i=0;i<resultArr.length;i++)
                     chklist=resultArr[i]+", ";*/
 
-                Cursor cursor = sqLite.getPackingItemChecked();
+                   Cursor cursor = sqLite.getPackingItemChecked();
 
-                while (cursor.moveToNext())
-                {
-                    q=cursor.getInt(cursor.getColumnIndex("Quantity"));
-                    item=cursor.getString(cursor.getColumnIndex("PackingItem"));
+                   while (cursor.moveToNext())
+                   {
+                       q=cursor.getInt(cursor.getColumnIndex("Quantity"));
+                       item=cursor.getString(cursor.getColumnIndex("PackingItem"));
 
-                    chklist+=q+" "+item+" ";
+                       chklist+=q+" "+item+" ";
 
-                }
-                mLocationPicked=locationSpinner.getText().toString();
-                mItemPicked = "Trip to " + mLocationPicked + " is scheduled on " + departure_formattedate + " till " + arrival_formattedate + ". Please bring following items:- " + chklist  +"\n";
+                   }
+                   mLocationPicked=locationSpinner.getText().toString();
+                   mItemPicked = "Trip to " + mLocationPicked + " is scheduled on " + departure_formattedate + " till " + arrival_formattedate + ". Please bring following items:- " + chklist  +"\n";
 
-                Calendar calendar = Calendar.getInstance();
-                Log.d(TAGTIFA, "Date:" + dep_year + " " + dep_month + " " + dep_day);
-                calendar.set(dep_year,dep_month,dep_day,ALARM_HOUR,ALARM_MINUTE,ALARM_SECONDS);
-                long deptime= calendar.getTimeInMillis();
-                long today= Calendar.getInstance().getTimeInMillis();
-                long interval=0;
-                Log.d(TAGTIFA,"Dep Time:"+deptime);
-                Log.d(TAGTIFA, "Today: " + today);
-                if(deptime>today) {
-                    interval = getTimeInterval(deptime, today);
-                    /**
-                     * Setting Up Alarm for a Week Before
-                     * A day Before
-                     * On day of Trip
-                     */
-                    long sevenDays = 6 * 24 * 60 * 60 * 1000;
-                    long oneDay = 24 * 60 * 60 * 1000;
-                    Log.d(TAGTIFA,"Alarm Interval: "+interval);
-                    if (interval >= 7) {
-                        Log.d(TAGTIFA,"Category 1 Alarm Set");
-                        Intent myIntent1 = new Intent(TripIndicatorFragmentActivity.this, TripAlarmReceiver.class);
-                        myIntent1.putExtra("AlarmID",101);
-                        pendingIntent = PendingIntent.getBroadcast(TripIndicatorFragmentActivity.this, 101, myIntent1, PendingIntent.FLAG_UPDATE_CURRENT);
-                        alarmManager.set(AlarmManager.RTC_WAKEUP, calendar.getTimeInMillis() - sevenDays, pendingIntent);
+                   Calendar calendar = Calendar.getInstance();
+                   Log.d(TAGTIFA, "Date:" + dep_year + " " + dep_month + " " + dep_day);
+                   calendar.set(dep_year,dep_month,dep_day,ALARM_HOUR,ALARM_MINUTE,ALARM_SECONDS);
+                   long deptime= calendar.getTimeInMillis();
+                   long today= Calendar.getInstance().getTimeInMillis();
+                   long interval=0;
+                   Log.d(TAGTIFA,"Dep Time:"+deptime);
+                   Log.d(TAGTIFA, "Today: " + today);
+                   if(deptime>today) {
+                       interval = getTimeInterval(deptime, today);
+                       /**
+                        * Setting Up Alarm for a Week Before
+                        * A day Before
+                        * On day of Trip
+                        */
+                       long sevenDays = 6 * 24 * 60 * 60 * 1000;
+                       long oneDay = 24 * 60 * 60 * 1000;
+                       Log.d(TAGTIFA,"Alarm Interval: "+interval);
+                       if (interval >= 7) {
+                           Log.d(TAGTIFA,"Category 1 Alarm Set");
+                           Intent myIntent1 = new Intent(TripIndicatorFragmentActivity.this, TripAlarmReceiver.class);
+                           myIntent1.putExtra("AlarmID",101);
+                           pendingIntent = PendingIntent.getBroadcast(TripIndicatorFragmentActivity.this, 101, myIntent1, PendingIntent.FLAG_UPDATE_CURRENT);
+                           alarmManager.set(AlarmManager.RTC_WAKEUP, calendar.getTimeInMillis() - sevenDays, pendingIntent);
 
-                        Intent myIntent2 = new Intent(TripIndicatorFragmentActivity.this, TripAlarmReceiver.class);
-                        myIntent2.putExtra("AlarmID",102);
-                        pendingIntent = PendingIntent.getBroadcast(TripIndicatorFragmentActivity.this, 102, myIntent2, PendingIntent.FLAG_UPDATE_CURRENT);
-                        alarmManager.set(AlarmManager.RTC_WAKEUP, calendar.getTimeInMillis() - oneDay, pendingIntent);
+                           Intent myIntent2 = new Intent(TripIndicatorFragmentActivity.this, TripAlarmReceiver.class);
+                           myIntent2.putExtra("AlarmID",102);
+                           pendingIntent = PendingIntent.getBroadcast(TripIndicatorFragmentActivity.this, 102, myIntent2, PendingIntent.FLAG_UPDATE_CURRENT);
+                           alarmManager.set(AlarmManager.RTC_WAKEUP, calendar.getTimeInMillis() - oneDay, pendingIntent);
 
-                        Intent myIntent3 = new Intent(TripIndicatorFragmentActivity.this, TripAlarmReceiver.class);
-                        myIntent3.putExtra("AlarmID",103);
-                        pendingIntent = PendingIntent.getBroadcast(TripIndicatorFragmentActivity.this, 103, myIntent3, PendingIntent.FLAG_UPDATE_CURRENT );
-                        alarmManager.set(AlarmManager.RTC_WAKEUP, calendar.getTimeInMillis(), pendingIntent);
-                        Toast.makeText(getApplicationContext(), "Reminders are Set!", Toast.LENGTH_LONG).show();
-                    } else if (interval < 7 && interval > 1) {
+                           Intent myIntent3 = new Intent(TripIndicatorFragmentActivity.this, TripAlarmReceiver.class);
+                           myIntent3.putExtra("AlarmID",103);
+                           pendingIntent = PendingIntent.getBroadcast(TripIndicatorFragmentActivity.this, 103, myIntent3, PendingIntent.FLAG_UPDATE_CURRENT );
+                           alarmManager.set(AlarmManager.RTC_WAKEUP, calendar.getTimeInMillis(), pendingIntent);
+                           Toast.makeText(getApplicationContext(), "Reminders are Set!", Toast.LENGTH_LONG).show();
+                       } else if (interval < 7 && interval > 1) {
 
-                        Log.d(TAGTIFA,"Category 2 Alarm Set");
-                        Intent myIntent1 = new Intent(TripIndicatorFragmentActivity.this, TripAlarmReceiver.class);
-                        myIntent1.putExtra("AlarmID",102);
-                        pendingIntent = PendingIntent.getBroadcast(TripIndicatorFragmentActivity.this, 102, myIntent1, PendingIntent.FLAG_UPDATE_CURRENT);
-                        alarmManager.set(AlarmManager.RTC_WAKEUP, calendar.getTimeInMillis() - oneDay, pendingIntent);
-                        Intent myIntent2 = new Intent(TripIndicatorFragmentActivity.this, TripAlarmReceiver.class);
-                        myIntent2.putExtra("AlarmID",103);
-                        pendingIntent = PendingIntent.getBroadcast(TripIndicatorFragmentActivity.this, 103, myIntent2, PendingIntent.FLAG_UPDATE_CURRENT);
-                        alarmManager.set(AlarmManager.RTC_WAKEUP, calendar.getTimeInMillis(), pendingIntent);
-                        Toast.makeText(getApplicationContext(), "Reminders are Set!", Toast.LENGTH_LONG).show();
+                           Log.d(TAGTIFA,"Category 2 Alarm Set");
+                           Intent myIntent1 = new Intent(TripIndicatorFragmentActivity.this, TripAlarmReceiver.class);
+                           myIntent1.putExtra("AlarmID",102);
+                           pendingIntent = PendingIntent.getBroadcast(TripIndicatorFragmentActivity.this, 102, myIntent1, PendingIntent.FLAG_UPDATE_CURRENT);
+                           alarmManager.set(AlarmManager.RTC_WAKEUP, calendar.getTimeInMillis() - oneDay, pendingIntent);
+                           Intent myIntent2 = new Intent(TripIndicatorFragmentActivity.this, TripAlarmReceiver.class);
+                           myIntent2.putExtra("AlarmID",103);
+                           pendingIntent = PendingIntent.getBroadcast(TripIndicatorFragmentActivity.this, 103, myIntent2, PendingIntent.FLAG_UPDATE_CURRENT);
+                           alarmManager.set(AlarmManager.RTC_WAKEUP, calendar.getTimeInMillis(), pendingIntent);
+                           Toast.makeText(getApplicationContext(), "Reminders are Set!", Toast.LENGTH_LONG).show();
 
-                    } else {
-                        Log.d(TAGTIFA,"Category 3 Alarm Set");
-                        Intent myIntent = new Intent(TripIndicatorFragmentActivity.this, TripAlarmReceiver.class);
-                        myIntent.putExtra("AlarmID",103);
-                        pendingIntent = PendingIntent.getBroadcast(TripIndicatorFragmentActivity.this, 103, myIntent, PendingIntent.FLAG_UPDATE_CURRENT);
-                        alarmManager.set(AlarmManager.RTC_WAKEUP, calendar.getTimeInMillis(), pendingIntent);
-                        Toast.makeText(getApplicationContext(), "Reminders are Set!", Toast.LENGTH_LONG).show();
-                    }
-                }
-                else
-                {
-                    Toast.makeText(getApplicationContext(),"Enter future departure time.", Toast.LENGTH_LONG).show();
-                }
+                       } else {
+                           Log.d(TAGTIFA,"Category 3 Alarm Set");
+                           Intent myIntent = new Intent(TripIndicatorFragmentActivity.this, TripAlarmReceiver.class);
+                           myIntent.putExtra("AlarmID",103);
+                           pendingIntent = PendingIntent.getBroadcast(TripIndicatorFragmentActivity.this, 103, myIntent, PendingIntent.FLAG_UPDATE_CURRENT);
+                           alarmManager.set(AlarmManager.RTC_WAKEUP, calendar.getTimeInMillis(), pendingIntent);
+                           Toast.makeText(getApplicationContext(), "Reminders are Set!", Toast.LENGTH_LONG).show();
+                       }
+                   }
+                   else
+                   {
+                       Toast.makeText(getApplicationContext(),"Enter future departure time.", Toast.LENGTH_LONG).show();
+                   }
 
 
 
-                loc = locationSpinner.getText().toString();
-                sqLite.insertLocation(loc);
+                   loc = locationSpinner.getText().toString();
+                   sqLite.insertLocation(loc);
+               }
 
 
             }
@@ -329,17 +354,24 @@ public class TripIndicatorFragmentActivity extends FragmentActivity {
             @Override
             public void onClick(View v) {
 
-                Intent intent = new Intent(getApplication(), TripIndicatorPackingActivity.class);
+                  if(departureMonth.getText().toString().equals("") || arrivalMonth.getText().toString().equals("") )
+                {
+                    Toast.makeText(getApplicationContext(),"Enter Departure Date and Arrival Date First ",Toast.LENGTH_SHORT).show();
+                }
+               else
+                {
+                    Intent intent = new Intent(getApplication(), TripIndicatorPackingActivity.class);
 
-                Log.d(TAGTIFA,departure_formattedate+"  "+arrival_formattedate);
+                    Log.d(TAGTIFA,departure_formattedate+"  "+arrival_formattedate);
 
-                setNumDrugs(departure_formattedate, arrival_formattedate);
+                    setNumDrugs(departure_formattedate, arrival_formattedate);
 
-                intent.putExtra(DRUG_TAG, num_drugs);
+                    intent.putExtra(DRUG_TAG, num_drugs);
 
-                startActivity(intent);
+                    startActivity(intent);
 
-                packingSelect.setText(TripIndicatorPackingActivity.tripDrugName);
+                    packingSelect.setText(TripIndicatorPackingActivity.tripDrugName);
+                }
             }
         });
 
@@ -362,14 +394,14 @@ public class TripIndicatorFragmentActivity extends FragmentActivity {
         dialog.setContentView(R.layout.resetdata_dialog);
         //dialog.setTitle("Reset Data");
 
-        final RadioGroup btnRadGroup = (RadioGroup) dialog.findViewById(R.id.radioGroupReset);
+        //final RadioGroup btnRadGroup = (RadioGroup) dialog.findViewById(R.id.radioGroupReset);
         Button btnOK = (Button) dialog.findViewById(R.id.dialogButtonOKReset);
 
         btnOK.setOnClickListener(new View.OnClickListener() {
             @Override
             public void onClick(View v) {
 
-                // get selected radio button from radioGroup
+             /*   // get selected radio button from radioGroup
                 int selectedId = btnRadGroup.getCheckedRadioButtonId();
 
                 // find the radiobutton by returned id
@@ -387,7 +419,13 @@ public class TripIndicatorFragmentActivity extends FragmentActivity {
 
                 } else {
                     dialog.dismiss();
-                }
+                }*/
+                DatabaseSQLiteHelper sqLite = new DatabaseSQLiteHelper(getApplicationContext());
+                sqLite.resetDatabase();
+                mSharedPreferenceStore.mEditor.clear().commit();
+                SharedPreferenceStore.mEditor.clear().commit();
+                startActivity(new Intent(getApplication().getApplicationContext(),
+                        UserMedicineSettingsFragmentActivity.class));
 
             }
         });

--- a/src/com/peacecorps/malaria/TripIndicatorFragmentActivity.java
+++ b/src/com/peacecorps/malaria/TripIndicatorFragmentActivity.java
@@ -451,13 +451,13 @@ public class TripIndicatorFragmentActivity extends FragmentActivity {
         String date_data=dateData.getText().toString();
         String month_data=monthData.getText().toString();
         String year_data=yearData.getText().toString();
-        arrival_formattedate=month_data+"/"+date_data+"/"+year_data;
+        arrival_formattedate=date_data+"/"+month_data+"/"+year_data;
         SharedPreferenceStore.mEditor.putString("com.peacecorps.malaria.trip_date", arrival_formattedate).commit();
 
         String departure_date_data=DepartureDateData.getText().toString();
         String departure_month_data=DepartureMonthData.getText().toString();
         String departure_year_data=DepartureYearData.getText().toString();
-        departure_formattedate=departure_month_data+"/"+departure_date_data+"/"+departure_year_data;
+        departure_formattedate=departure_date_data+"/"+departure_month_data+"/"+departure_year_data;
 
         SharedPreferenceStore.mEditor.putString("com.peacecorps.malaria.departure_trip_date", departure_formattedate).commit();
         SharedPreferenceStore.mEditor.putString("com.peacecorps.malaria.trip_drug",mDrugPicked).commit();

--- a/src/com/peacecorps/malaria/TripIndicatorPackingActivity.java
+++ b/src/com/peacecorps/malaria/TripIndicatorPackingActivity.java
@@ -30,7 +30,7 @@ public class TripIndicatorPackingActivity extends Activity {
     private long mNumDrugs=0;
     TextView numDrugs;
     ListView listView;
-    EditText cash;
+    EditText cash,edit;
     TextView whichDrug;
     public static String tripDrugName;
 
@@ -72,6 +72,9 @@ public class TripIndicatorPackingActivity extends Activity {
         /** List View **/
         listView = (ListView)findViewById(R.id.listV);
 
+        /**Description of the new item added**/
+        edit = (EditText) findViewById(R.id.packing_et);
+
         /**Populating the List **/
         Cursor cursor = sqLite.getPackingItem();
         String item="";
@@ -102,12 +105,20 @@ public class TripIndicatorPackingActivity extends Activity {
         View.OnClickListener listenerAdd = new View.OnClickListener() {
             @Override
             public void onClick(View v) {
-                EditText edit = (EditText) findViewById(R.id.packing_et);
--                list.add(edit.getText().toString());
--                sqLite.insertPackingItem(edit.getText().toString(),1,"no");
--                edit.setText("");
--                adapter.notifyDataSetChanged();
+                String s=edit.getText().toString();
+                if(s.equals(""))
+                {
+                    Toast.makeText(getApplicationContext(), "Enter item name ", Toast.LENGTH_SHORT).show();
 
+                }
+                else
+                {
+                    list.add(edit.getText().toString());
+                    sqLite.insertPackingItem(edit.getText().toString(),1,"no");
+                    edit.setText("");
+                    adapter.notifyDataSetChanged();
+
+                }
             }
         };
 
@@ -202,6 +213,7 @@ public class TripIndicatorPackingActivity extends Activity {
         mNumDrugs=intent.getLongExtra(TripIndicatorFragmentActivity.DRUG_TAG,0);
         numDrugs = (TextView)findViewById(R.id.quantity);
         whichDrug = (TextView)findViewById(R.id.drugName);
+
         sqLite.insertPackingItem("Pills", (int) mNumDrugs, "yes");
 
         /** Drug Selection **/

--- a/src/com/peacecorps/malaria/TripIndicatorPackingActivity.java
+++ b/src/com/peacecorps/malaria/TripIndicatorPackingActivity.java
@@ -7,6 +7,7 @@ import android.content.Context;
 import android.content.Intent;
 import android.database.Cursor;
 import android.os.Bundle;
+import android.util.Log;
 import android.util.SparseBooleanArray;
 import android.view.View;
 import android.widget.AdapterView;
@@ -29,7 +30,7 @@ public class TripIndicatorPackingActivity extends Activity {
     private long mNumDrugs=0;
     TextView numDrugs;
     ListView listView;
-    EditText cash;
+    EditText cash,edit;
     TextView whichDrug;
     public static String tripDrugName;
 
@@ -71,6 +72,10 @@ public class TripIndicatorPackingActivity extends Activity {
         /** List View **/
         listView = (ListView)findViewById(R.id.listV);
 
+        /**Description of the new item added**/
+        edit = (EditText) findViewById(R.id.packing_et);
+
+
         /**Populating the List **/
         Cursor cursor = sqLite.getPackingItem();
         String item="";
@@ -101,11 +106,21 @@ public class TripIndicatorPackingActivity extends Activity {
         View.OnClickListener listenerAdd = new View.OnClickListener() {
             @Override
             public void onClick(View v) {
-                EditText edit = (EditText) findViewById(R.id.packing_et);
-                list.add(edit.getText().toString());
-                sqLite.insertPackingItem(edit.getText().toString(),1,"no");
-                edit.setText("");
-                adapter.notifyDataSetChanged();
+                String s=edit.getText().toString();
+
+                if(s.equals(""))
+                {
+                    Toast.makeText(getApplicationContext(), "Enter item name ", Toast.LENGTH_SHORT).show();
+
+                }
+                else
+                {
+                    list.add(edit.getText().toString());
+                    sqLite.insertPackingItem(edit.getText().toString(),1,"no");
+                    edit.setText("");
+                    adapter.notifyDataSetChanged();
+
+                }
             }
         };
 
@@ -200,7 +215,6 @@ public class TripIndicatorPackingActivity extends Activity {
         mNumDrugs=intent.getLongExtra(TripIndicatorFragmentActivity.DRUG_TAG,0);
         numDrugs = (TextView)findViewById(R.id.quantity);
         whichDrug = (TextView)findViewById(R.id.drugName);
-        numDrugs.setText("" + mNumDrugs);
         sqLite.insertPackingItem("Pills", (int) mNumDrugs, "yes");
 
         /** Drug Selection **/
@@ -244,11 +258,37 @@ public class TripIndicatorPackingActivity extends Activity {
                 //setting the text to the drug selected
                 whichDrug.setText(parent.getItemAtPosition(position).toString());
                 tripDrugName=parent.getItemAtPosition(position).toString();
+                setNumberOfDrugs();
                 TripIndicatorFragmentActivity.packingSelect.setText(mNumDrugs + " " + tripDrugName + " etc.");
                 dialog.dismiss();
             }
         });
             return dialog;
+
+    }
+
+    protected void  setNumberOfDrugs()
+    {
+        if(tripDrugName.equals("Malarone"))
+        {
+            numDrugs.setText("" + mNumDrugs);
+        }
+        else if(tripDrugName.equals("Doxycycline") || tripDrugName.equals("Mefloquine"))
+        {   if(mNumDrugs%7==0)
+        {
+            numDrugs.setText("" + mNumDrugs/7);
+        }
+        else
+        {
+            numDrugs.setText("" +(( mNumDrugs/7)+1));
+        }
+
+
+        }
+        else
+        {
+            numDrugs.setText("");
+        }
 
     }
 

--- a/src/com/peacecorps/malaria/TripIndicatorPackingActivity.java
+++ b/src/com/peacecorps/malaria/TripIndicatorPackingActivity.java
@@ -30,7 +30,7 @@ public class TripIndicatorPackingActivity extends Activity {
     private long mNumDrugs=0;
     TextView numDrugs;
     ListView listView;
-    EditText cash,edit;
+    EditText cash;
     TextView whichDrug;
     public static String tripDrugName;
 
@@ -72,10 +72,6 @@ public class TripIndicatorPackingActivity extends Activity {
         /** List View **/
         listView = (ListView)findViewById(R.id.listV);
 
-        /**Description of the new item added**/
-        edit = (EditText) findViewById(R.id.packing_et);
-
-
         /**Populating the List **/
         Cursor cursor = sqLite.getPackingItem();
         String item="";
@@ -106,21 +102,12 @@ public class TripIndicatorPackingActivity extends Activity {
         View.OnClickListener listenerAdd = new View.OnClickListener() {
             @Override
             public void onClick(View v) {
-                String s=edit.getText().toString();
+                EditText edit = (EditText) findViewById(R.id.packing_et);
+-                list.add(edit.getText().toString());
+-                sqLite.insertPackingItem(edit.getText().toString(),1,"no");
+-                edit.setText("");
+-                adapter.notifyDataSetChanged();
 
-                if(s.equals(""))
-                {
-                    Toast.makeText(getApplicationContext(), "Enter item name ", Toast.LENGTH_SHORT).show();
-
-                }
-                else
-                {
-                    list.add(edit.getText().toString());
-                    sqLite.insertPackingItem(edit.getText().toString(),1,"no");
-                    edit.setText("");
-                    adapter.notifyDataSetChanged();
-
-                }
             }
         };
 


### PR DESCRIPTION
Number of drugs required for trip were calculated incorrectly.
Example
 for 1 Jan 2015 to 1 Feb 2015 ...Numbers of dugs=1;
 for 1 Jan 2015 to to 2 Jan 2015  ....Numbers of dugs=31;
This was because the month and day were flipped which  gave wrong calculations.
Fixed the bug . Now 
 for 1 Jan 2015 to 1 Feb 2015 ...Numbers of dugs=31;
 for 1 Jan 2015 to to 2 Jan 2015  ....Numbers of dugs=1;

Also reduced the textsize of the textview displaying Number of medicines on trip_indicator_packing_dialog, as earlier it was showing maximum upto 2 digits. Rest of the digit were getting hidden due to lack of space. Thus 365 appeared as 36. 
After textsize reduction the problem is solved.