### PR TITLE
Add information buttons for drug spinner in setup screen

### DIFF
--- a/res/layout/trip_drug_info.xml
+++ b/res/layout/trip_drug_info.xml
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="utf-8"?>
+<TableLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent" >
+    <TableRow>
+        <Button
+            android:id="@+id/infoDrug"
+            android:layout_width="20dp"
+            android:layout_height="20dp"
+            android:layout_marginTop="10dp"
+            android:background="@drawable/info_hub_normal"
+            android:focusable="false"/>
+
+        <TextView
+            android:id="@+id/nameDrug"
+            android:layout_width="wrap_content"
+            android:layout_height="40dp"
+            android:textColor="@color/golden_brown"
+            android:textSize="15dp"
+            android:padding="10dp"/>
+
+    </TableRow>
+</TableLayout>

--- a/res/values/strings.xml
+++ b/res/values/strings.xml
@@ -37,7 +37,36 @@
     <string name="items_spinner_label">Pick Items</string>
     <string name="trip_select_string">Add Packing Items</string>
     <string name="dump_test">Fetching...</string>
-
+    <string name="mal_description">
+        -Interferes with growth of parasites in red blood cells\n
+        -Take the medicine everyday at the same time with food\n
+        -Start using 1-2 days before entering the area\n
+        -Continue using through out the stay,and at least 7 days after leave\n
+        -Take missed doses as soon as possible, but skip them if it is almost time for next dose\n
+        -Consult your doctor if you have liver or kidney disease, or malaria complications\n
+        -Some side effects of drug: stomach pain, headache, diarrhea, fever, weakness\n
+        -Visit http://www.drugs.com/malarone.html for more information\n
+    </string>
+    <string name="doxy_description">
+        -Tetracycline antibiotic that helps to fight bacteria in the body\n
+        -Take the medicine everyday at the same time with food\n
+        -Start using 1-2 days before entering the area\n
+        -Continue using through out the stay,and at least 28 days after leave\n
+        -Take missed doses as soon as possible, but skip them if it is almost time for next dose\n
+        -Consult your doctor if you have liver or kidney disease, or are taking supplements and other medicines\n
+        -Some side effects of drug: stomach pain, headache, diarrhea, fever, weakness\n
+        -Visit http://www.drugs.com/doxycycline.html for more information\n
+    </string>
+    <string name="mef_description">
+        -Antimalarial agent that kills sensitive malaria parasites\n
+        -Take the medicine once a week after your main meal (NOT ON AN EMPTY STOMACH)\n
+        -Start using 1 week before entering the area\n
+        -Continue using through out the stay,and at least 4 weeks after leave\n
+        -Take missed doses as soon as possible, but skip them if it is almost time for next dose\n
+        -Consult your doctor if you have allergies, mental illnesses, seizures, or are taking similar medicines\n
+        -Some side effects of drug: stomach pain, headache, muscle ache, tiredness, vomiting\n
+        -Visit http://www.drugs.com/cdi/mefloquine.html for more information\n
+    </string>
 
     <string-array name="user_medicine_settings_activity_drug_array">
         <item>Malarone (Daily)</item>

--- a/src/com/peacecorps/malaria/DrugArrayAdapter.java
+++ b/src/com/peacecorps/malaria/DrugArrayAdapter.java
@@ -3,12 +3,17 @@ package com.peacecorps.malaria;
 /**
  * Created by Ankita on 8/13/2015.
  */
+import android.app.ActionBar;
 import android.app.Activity;
+import android.app.AlertDialog;
 import android.view.LayoutInflater;
+import android.view.MotionEvent;
 import android.view.View;
 import android.view.ViewGroup;
 import android.widget.ArrayAdapter;
+import android.widget.Button;
 import android.widget.ImageView;
+import android.widget.TableLayout;
 import android.widget.TextView;
 
 public class DrugArrayAdapter extends ArrayAdapter<String>{
@@ -16,12 +21,14 @@ public class DrugArrayAdapter extends ArrayAdapter<String>{
     private final Activity context;
     private final String[] dname;
     private final Integer[] imageId;
+    private final String[] drugDescriptions;
     public DrugArrayAdapter(Activity context,
-                      String[] dname, Integer[] imageId) {
+                      String[] dname, Integer[] imageId, String[] drugDescriptions) {
         super(context, R.layout.trip_drug_item, dname);
         this.context = context;
         this.dname = dname;
         this.imageId = imageId;
+        this.drugDescriptions = drugDescriptions;
 
     }
     @Override
@@ -36,5 +43,33 @@ public class DrugArrayAdapter extends ArrayAdapter<String>{
 
         imageView.setImageResource(imageId[position]);
         return rowView;
+    }
+
+    @Override
+    public View getDropDownView(int position, View View, ViewGroup parent) {
+        LayoutInflater inflater = context.getLayoutInflater();
+        //inflating the customized view
+        View rowView= inflater.inflate(R.layout.trip_drug_info, null, true);
+        final TextView txtTitle = (TextView) rowView.findViewById(R.id.nameDrug);
+        Button infoButton = (Button) rowView.findViewById(R.id.infoDrug);
+
+        txtTitle.setText(dname[position]);
+        addClickListener(position, infoButton);
+
+        return rowView;
+    }
+    //When the info button is clicked for the drug, an alert dialog will show its description
+    public void addClickListener(final int position, Button infoButton) {
+        infoButton.setOnClickListener(new View.OnClickListener() {
+            @Override
+            public void onClick(View v) {
+                AlertDialog.Builder dialogAlert  = new AlertDialog.Builder(context);
+                dialogAlert.setMessage(drugDescriptions[position]);
+                dialogAlert.setTitle(dname[position]);
+                dialogAlert.setPositiveButton("OK", null);
+                dialogAlert.setCancelable(true);
+                dialogAlert.create().show();
+            }
+        });
     }
 }

--- a/src/com/peacecorps/malaria/TripIndicatorPackingActivity.java
+++ b/src/com/peacecorps/malaria/TripIndicatorPackingActivity.java
@@ -236,7 +236,7 @@ public class TripIndicatorPackingActivity extends Activity {
         dialog.setCancelable(true);
         dialog.setCanceledOnTouchOutside(true);
         dialog_listView=(ListView)dialog.findViewById(R.id.tripDrugDialogList);
-        DrugArrayAdapter adapter = new DrugArrayAdapter(this,listContent,imageId);
+        DrugArrayAdapter adapter = new DrugArrayAdapter(this,listContent,imageId,null);
         dialog_listView.setAdapter(adapter);
         dialog_listView.setOnItemClickListener(new AdapterView.OnItemClickListener() {
             @Override

--- a/src/com/peacecorps/malaria/UserMedicineSettingsFragmentActivity.java
+++ b/src/com/peacecorps/malaria/UserMedicineSettingsFragmentActivity.java
@@ -172,8 +172,12 @@ public class UserMedicineSettingsFragmentActivity extends FragmentActivity
                 android.R.layout.simple_spinner_item);*/
         String[] listContent = {"Malarone","Doxycycline","Mefloquine"};
         Integer[] imageID = {R.drawable.mal,R.drawable.doxy,R.drawable.mef};
-
-        DrugArrayAdapter adapter = new DrugArrayAdapter(this,listContent,imageID);
+        String[] descriptions = {
+                getString(R.string.mal_description),
+                getString(R.string.doxy_description),
+                getString(R.string.mef_description),
+        };
+        DrugArrayAdapter adapter = new DrugArrayAdapter(this, listContent, imageID, descriptions);
 
         adapter.setDropDownViewResource(android.R.layout.simple_spinner_dropdown_item);
         mDrugSelectSpinner.setAdapter(adapter);


### PR DESCRIPTION
I added information icons for each drug in the spinner in the setup screen, so that when the user clicks them they get more information about the drug. The main change is overriding getDropDownView in DrugArrayAdapter
example:
![hi](https://cloud.githubusercontent.com/assets/16299227/12012800/439953ae-acd3-11e5-96c9-ecebdbd83960.gif)
