### PR TITLE
Improve packing item list in trip indicator

### DIFF
--- a/res/layout/trip_indicator_packing_dialog.xml
+++ b/res/layout/trip_indicator_packing_dialog.xml
@@ -136,6 +136,7 @@
             <EditText
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
+		android:maxWidth="110dp"
                 android:hint="Add Items"
                 android:id="@+id/packing_et"
                 android:layout_marginLeft="15dp"

--- a/src/com/peacecorps/malaria/TripIndicatorPackingActivity.java
+++ b/src/com/peacecorps/malaria/TripIndicatorPackingActivity.java
@@ -114,6 +114,9 @@ public class TripIndicatorPackingActivity extends Activity {
 
         /** Setting the adapter to the ListView */
         listView.setAdapter(adapter);
+		
+		/** Setting the event listeners for the list view */
+        addListViewListeners();
 
         View.OnClickListener listenerDelete = new View.OnClickListener() {
             @Override
@@ -216,7 +219,43 @@ public class TripIndicatorPackingActivity extends Activity {
 
 
     }
+	
+    private void addListViewListeners() {
+        listView.setOnScrollListener(new AbsListView.OnScrollListener() {
+            @Override
+            public void onScrollStateChanged(AbsListView view, int scrollState) {
 
+            }
+
+            //Update on a scroll, as viewable children may change
+            @Override
+            public void onScroll(AbsListView view, int firstVisibleItem, int visibleItemCount, int totalItemCount) {
+                updateChildBackgrounds();
+            }
+        });
+
+        listView.setOnItemClickListener(new AdapterView.OnItemClickListener() {
+            //Update on an item click, as colours change
+            @Override
+            public void onItemClick(AdapterView<?> parent, View view, int position, long id) {
+                updateChildBackgrounds();
+            }
+        });
+    }
+	
+    //Updates in view checked items to green, and unchecked items to red
+    private void updateChildBackgrounds() {
+        SparseBooleanArray checkedItemPositions = listView.getCheckedItemPositions();
+        for (int i = 0 ; i < listView.getChildCount() ; i++) {
+            int actualPosition = listView.getFirstVisiblePosition() + i;
+            if (checkedItemPositions.get(actualPosition)) {
+                listView.getChildAt(i).setBackgroundResource(R.color.light_green);
+            } else {
+                listView.getChildAt(i).setBackgroundResource(R.color.light_red);
+            }
+        }
+    }
+    
     private void getSharedPreferences() {
         // reading the application SharedPreferences for storing of time and
         // drug selected


### PR DESCRIPTION
The item icons no longer get squished when a long name is typed
![gif1](https://cloud.githubusercontent.com/assets/16299227/12045598/813ae7c0-ae74-11e5-8504-78641d7401be.gif)
Check boxes are now color coded based on whether they are checked or not
![gif2](https://cloud.githubusercontent.com/assets/16299227/12045604/93d64f50-ae74-11e5-9e16-0d90867090fc.gif)
