### PR TITLE
Fix to delete Packaging Items from database when deleted in TripIndicatorPackingActivity

### DIFF
--- a/AndroidManifest.xml
+++ b/AndroidManifest.xml
@@ -73,6 +73,7 @@
         <activity android:name="com.peacecorps.malaria.DayFragmentActivity"/>
         <activity android:name="com.peacecorps.malaria.TripIndicatorFragmentActivity"
                   android:launchMode="singleTask"
+                  android:windowSoftInputMode="adjustPan"
                   />
 
         <activity android:name="com.peacecorps.malaria.TripIndicatorDialogActivity"

--- a/src/com/peacecorps/malaria/DatabaseSQLiteHelper.java
+++ b/src/com/peacecorps/malaria/DatabaseSQLiteHelper.java
@@ -688,6 +688,17 @@ public class DatabaseSQLiteHelper extends SQLiteOpenHelper {
 
     }
 
+    /**Delete Packing Item**/
+
+    public void deletePackingItem(String pItem)
+    {
+
+        SQLiteDatabase sqDB = getWritableDatabase();
+        sqDB.delete(packingTable,"PackingItem= ?", new String[]{ pItem });
+        sqDB.close();
+        
+    }
+
 
     /**Refreshing the status of each packing item to its original state**/
     public void refreshPackingItemStatus()

--- a/src/com/peacecorps/malaria/TripIndicatorPackingActivity.java
+++ b/src/com/peacecorps/malaria/TripIndicatorPackingActivity.java
@@ -128,6 +128,7 @@ public class TripIndicatorPackingActivity extends Activity {
 
                 for(int i=itemCount-1; i >= 0; i--){
                     if(checkedItemPositions.get(i)){
+                        sqLite.deletePackingItem(list.get(i));
                         adapter.remove(list.get(i));
                     }
                 }


### PR DESCRIPTION
Currently, when the delete button is clicked in `TripIndicatorPackingActivity`, packaging items are deleted only from the adapter. They are not removed from local sqlite database. So, when the activity is again back on top of stack or is again instantiated the items deleted are still populated in the ListView.

The fix added the instruction to delete the item also from the local database.