### PR TITLE
Fixed crashing of app in SecondAnalyticFragment

### DIFF
--- a/src/com/peacecorps/malaria/SecondAnalyticFragment.java
+++ b/src/com/peacecorps/malaria/SecondAnalyticFragment.java
@@ -109,18 +109,19 @@ public class SecondAnalyticFragment extends Fragment {
     //finding month from its integer
     public String getMonth(int date) {
         String month[] = getResources().getStringArray(R.array.month);
-        if (date == 0) {
-            date = 12;
-            myear = Calendar.getInstance().get(Calendar.YEAR) - 1;
-        } else if (date == -1) {
+        if (date == -1) {
             date = 11;
             myear = Calendar.getInstance().get(Calendar.YEAR) - 1;
         } else if (date == -2) {
             date = 10;
             myear = Calendar.getInstance().get(Calendar.YEAR) - 1;
+        } else if (date == -3) {
+            date = 9;
+            myear = Calendar.getInstance().get(Calendar.YEAR) - 1;
+        } else {
+            myear = Calendar.getInstance().get(Calendar.YEAR);
+            mdate = date;
         }
-        myear = Calendar.getInstance().get(Calendar.YEAR);
-        mdate = date;
         return month[date];
     }
     /*Opening Dialog on Clicking Gear Icon*/


### PR DESCRIPTION
The app was crashing on the `SecondAnalyticFragment`. The application gave `java.lang.ArrayIndexOutOfBoundsException` in `getMonth(int date)` function. Also, there was a logical error assigning year and date in the `getMonth(int date)` function.