### PR TITLE
Line breaks omitted when loading data from cache.

### DIFF
--- a/src/com/peacecorps/malaria/EffectivenessFragmentActivity.java
+++ b/src/com/peacecorps/malaria/EffectivenessFragmentActivity.java
@@ -121,6 +121,7 @@ public class EffectivenessFragmentActivity extends FragmentActivity{
                     StringBuffer buffer = new StringBuffer();
                     while ((line = input.readLine()) != null) {
                         buffer.append(line);
+                        buffer.append("\n");
                     }
                     mEffectivenessLabel.setText(buffer.toString());
                     Log.d(TAGE, buffer.toString());

--- a/src/com/peacecorps/malaria/PercentSideEffectsFragmentActivity.java
+++ b/src/com/peacecorps/malaria/PercentSideEffectsFragmentActivity.java
@@ -126,6 +126,7 @@ public class PercentSideEffectsFragmentActivity extends FragmentActivity {
                     StringBuffer buffer = new StringBuffer();
                     while ((line = input.readLine()) != null) {
                         buffer.append(line);
+			buffer.append("\n");
                     }
                     mPercentSideEffectsLabel.setText(buffer.toString());
                     Log.d(TAGPSE, buffer.toString());

--- a/src/com/peacecorps/malaria/SideEffectsNPCVFragmentActivity.java
+++ b/src/com/peacecorps/malaria/SideEffectsNPCVFragmentActivity.java
@@ -124,6 +124,7 @@ public class SideEffectsNPCVFragmentActivity extends FragmentActivity {
                     StringBuffer buffer = new StringBuffer();
                     while ((line = input.readLine()) != null) {
                         buffer.append(line);
+			buffer.append("\n");
                     }
                     mSideEffectsNPCVLabel.setText(buffer.toString());
                     Log.d(TAGSEN, buffer.toString());

--- a/src/com/peacecorps/malaria/SideEffectsPCVFragmentActivity.java
+++ b/src/com/peacecorps/malaria/SideEffectsPCVFragmentActivity.java
@@ -125,6 +125,7 @@ public class SideEffectsPCVFragmentActivity extends FragmentActivity {
                     StringBuffer buffer = new StringBuffer();
                     while ((line = input.readLine()) != null) {
                         buffer.append(line);
+			buffer.append("\n");
                     }
                     mSideEffectsPCVLabel.setText(buffer.toString());
                     Log.d(TAGSEP, buffer.toString());

--- a/src/com/peacecorps/malaria/VolunteerAdherenceFragmentActivity.java
+++ b/src/com/peacecorps/malaria/VolunteerAdherenceFragmentActivity.java
@@ -125,6 +125,7 @@ public class VolunteerAdherenceFragmentActivity extends FragmentActivity {
                     StringBuffer buffer = new StringBuffer();
                     while ((line = input.readLine()) != null) {
                         buffer.append(line);
+			buffer.append("\n");
                     }
                     mVolunteerAdherenceLabel.setText(buffer.toString());
                     Log.d(TAGVA, buffer.toString());


### PR DESCRIPTION
When data is loaded in Info Hub from cache the line breaks are omitted as shown in fig. This happens because of the following code segment:
```java
 while ((line = input.readLine()) != null) {
                        buffer.append(line);
                    }
``` 
Here data is read line by line, but no newline is added. I added buffer.append("\n") to add newlines. Same has been done to all the necessary files.
```java
 while ((line = input.readLine()) != null) {
                        buffer.append(line);
                        buffer.append("\n");
                    }
```

(before)
![screenshot_2016-03-13-23-08-04](https://cloud.githubusercontent.com/assets/8321130/13730609/a2812ee0-e979-11e5-855d-98aa7e6f2cc4.png)

(after)
![screenshot_2016-03-14-00-28-26](https://cloud.githubusercontent.com/assets/8321130/13730685/b3359f6c-e97b-11e5-9d66-058007782144.png)

