### PR TITLE
Finish TripIndicatorFragment Activity after setting reminders.

### DIFF
--- a/src/com/peacecorps/malaria/TripIndicatorFragmentActivity.java
+++ b/src/com/peacecorps/malaria/TripIndicatorFragmentActivity.java
@@ -310,6 +310,8 @@ public class TripIndicatorFragmentActivity extends FragmentActivity {
                            pendingIntent = PendingIntent.getBroadcast(TripIndicatorFragmentActivity.this, 103, myIntent3, PendingIntent.FLAG_UPDATE_CURRENT );
                            alarmManager.set(AlarmManager.RTC_WAKEUP, calendar.getTimeInMillis(), pendingIntent);
                            Toast.makeText(getApplicationContext(), "Reminders are Set!", Toast.LENGTH_LONG).show();
+                           startActivity(new Intent(getApplication().getApplicationContext(), MainActivity.class));
+                           finish();
                        } else if (interval < 7 && interval > 1) {
 
                            Log.d(TAGTIFA,"Category 2 Alarm Set");
@@ -322,6 +324,8 @@ public class TripIndicatorFragmentActivity extends FragmentActivity {
                            pendingIntent = PendingIntent.getBroadcast(TripIndicatorFragmentActivity.this, 103, myIntent2, PendingIntent.FLAG_UPDATE_CURRENT);
                            alarmManager.set(AlarmManager.RTC_WAKEUP, calendar.getTimeInMillis(), pendingIntent);
                            Toast.makeText(getApplicationContext(), "Reminders are Set!", Toast.LENGTH_LONG).show();
+                           startActivity(new Intent(getApplication().getApplicationContext(), MainActivity.class));
+                           finish();
 
                        } else {
                            Log.d(TAGTIFA,"Category 3 Alarm Set");
@@ -330,6 +334,8 @@ public class TripIndicatorFragmentActivity extends FragmentActivity {
                            pendingIntent = PendingIntent.getBroadcast(TripIndicatorFragmentActivity.this, 103, myIntent, PendingIntent.FLAG_UPDATE_CURRENT);
                            alarmManager.set(AlarmManager.RTC_WAKEUP, calendar.getTimeInMillis(), pendingIntent);
                            Toast.makeText(getApplicationContext(), "Reminders are Set!", Toast.LENGTH_LONG).show();
+                           startActivity(new Intent(getApplication().getApplicationContext(), MainActivity.class));
+                           finish();
                        }
                    }
                    else


### PR DESCRIPTION
Earlier

``` java
pendingIntent = PendingIntent.getBroadcast(TripIndicatorFragmentActivity.this, 103, myIntent,
PendingIntent.FLAG_UPDATE_CURRENT);
alarmManager.set(AlarmManager.RTC_WAKEUP, calendar.getTimeInMillis(), pendingIntent);
Toast.makeText(getApplicationContext(), "Reminders are Set!", Toast.LENGTH_LONG).show();
```

Setting a reminder displayed a toast message, but did not finish the activity. Now, after setting the reminder, toast is diplayed and then the user is sent to the home page.

``` java
pendingIntent = PendingIntent.getBroadcast(TripIndicatorFragmentActivity.this, 103, myIntent,
PendingIntent.FLAG_UPDATE_CURRENT);
alarmManager.set(AlarmManager.RTC_WAKEUP, calendar.getTimeInMillis(), pendingIntent);
Toast.makeText(getApplicationContext(), "Reminders are Set!", Toast.LENGTH_LONG).show();
startActivity(new Intent(getApplication().getApplicationContext(), MainActivity.class));
finish();
```
