### PR TITLE
Handled NullPointerException in TripIndicatorFragmentActivity

### DIFF
--- a/src/com/peacecorps/malaria/TripIndicatorFragmentActivity.java
+++ b/src/com/peacecorps/malaria/TripIndicatorFragmentActivity.java
@@ -330,6 +330,10 @@ public class TripIndicatorFragmentActivity extends FragmentActivity {
             @Override
             public void onClick(View v) {
 
+            	if(departure_formattedate == null || arrival_formattedate == null){
+            		Toast.makeText(getApplicationContext(), "Set Departure and Arrival Date first!", Toast.LENGTH_LONG).show();
+            	}
+            	else{
                 Intent intent = new Intent(getApplication(), TripIndicatorPackingActivity.class);
 
                 Log.d(TAGTIFA,departure_formattedate+"  "+arrival_formattedate);
@@ -341,6 +345,7 @@ public class TripIndicatorFragmentActivity extends FragmentActivity {
                 startActivity(intent);
 
                 packingSelect.setText(TripIndicatorPackingActivity.tripDrugName);
+                }
             }
         });
 

--- a/src/com/peacecorps/malaria/TripIndicatorFragmentActivity.java
+++ b/src/com/peacecorps/malaria/TripIndicatorFragmentActivity.java
@@ -331,8 +331,9 @@ public class TripIndicatorFragmentActivity extends FragmentActivity {
             public void onClick(View v) {
 
             	if(departure_formattedate == null || arrival_formattedate == null){
-            		Toast.makeText(getApplicationContext(), "Set Departure and Arrival Date first!", Toast.LENGTH_LONG).show();
+            		Toast.makeText(getApplicationContext(), "Set Departure Date and Arrival Date first!", Toast.LENGTH_LONG).show();
             	}
+            	
             	else{
                 Intent intent = new Intent(getApplication(), TripIndicatorPackingActivity.class);
 


### PR DESCRIPTION
In TripIndicatorFragmentActivity, if user selects "Packing List" first, before entering the Departure Date and Arrival Date, NullPointerException is thrown. Number of pills cannot be calculated as Departure Date and Arrival Date are null. So, handled this case and added a toast if the user selects "Packing List" first.

![screenshot_2016-03-16-21-27-28](https://cloud.githubusercontent.com/assets/6483261/13819192/ab282156-ebbe-11e5-8439-2e0cc94d3111.png)
