### PR TITLE
Fix Issue #105 to add game information dialog

### DIFF
--- a/malaria-app-android/src/main/java/com/peacecorps/malaria/activities/NewHomeActivity.java
+++ b/malaria-app-android/src/main/java/com/peacecorps/malaria/activities/NewHomeActivity.java
@@ -1,6 +1,8 @@
 package com.peacecorps.malaria.activities;
 
 import android.app.Activity;
+import android.app.AlertDialog;
+import android.content.DialogInterface;
 import android.content.Intent;
 import android.os.Bundle;
 import android.view.View;
@@ -92,7 +94,25 @@ public class NewHomeActivity extends Activity{
         return new View.OnClickListener() {
             @Override
             public void onClick(View view) {
-                startActivity(new Intent(NewHomeActivity.this, MythFactGame.class));
+                AlertDialog alertDialog = new AlertDialog.Builder(NewHomeActivity.this).create();
+                alertDialog.setTitle("Myth Fact Game");
+                alertDialog.setMessage("Test your knowledge of Malaria! Drag the facts into the trash if they are a myth, or into the treasure chest if they are a fact. You get one point for each correct answer.");
+                alertDialog.setButton(AlertDialog.BUTTON_POSITIVE, "Play!",
+                        new DialogInterface.OnClickListener() {
+                            public void onClick(DialogInterface dialog, int which) {
+                                dialog.dismiss();
+                                startActivity(new Intent(NewHomeActivity.this, MythFactGame.class));
+                            }
+                        });
+                alertDialog.setButton(AlertDialog.BUTTON_NEGATIVE, "Cancel",
+                        new DialogInterface.OnClickListener() {
+                            public void onClick(DialogInterface dialog, int which) {
+                                dialog.dismiss();
+                        }
+                        });
+                alertDialog.show();
+
+
             }
         };
     }
@@ -101,7 +121,23 @@ public class NewHomeActivity extends Activity{
         return new View.OnClickListener() {
             @Override
             public void onClick(View view) {
-                startActivity(new Intent(NewHomeActivity.this, RapidFireGame.class));
+                AlertDialog alertDialog = new AlertDialog.Builder(NewHomeActivity.this).create();
+                alertDialog.setTitle("Rapid Fire Game");
+                alertDialog.setMessage("Test your knowledge of Malaria! You have 5 seconds to choose the correct answer to fill in the blank or complete the sentence about malaria. You get one point for each correct answer.");
+                alertDialog.setButton(AlertDialog.BUTTON_POSITIVE, "Play!",
+                        new DialogInterface.OnClickListener() {
+                            public void onClick(DialogInterface dialog, int which) {
+                                dialog.dismiss();
+                                startActivity(new Intent(NewHomeActivity.this, RapidFireGame.class));
+                            }
+                        });
+                alertDialog.setButton(AlertDialog.BUTTON_NEGATIVE, "Cancel",
+                        new DialogInterface.OnClickListener() {
+                            public void onClick(DialogInterface dialog, int which) {
+                                dialog.dismiss();
+                            }
+                        });
+                alertDialog.show();
             }
         };
     }

--- a/malaria-app-android/src/main/java/com/peacecorps/malaria/activities/NewHomeActivity.java
+++ b/malaria-app-android/src/main/java/com/peacecorps/malaria/activities/NewHomeActivity.java
@@ -99,20 +99,20 @@ public class NewHomeActivity extends Activity{
                 alertDialog.setCancelable(false);
 
                 // Setting Dialog Title
-                TextView title = (TextView) alertDialog.findViewById(R.id.gameTitle);
-                TextView description = (TextView) alertDialog.findViewById(R.id.gameInfoDescription);
-                title.setText(R.string.myth_fact_game);
-                description.setText(R.string.myth_fact_description);
-                Button cancel = (Button) alertDialog.findViewById(R.id.noGameDialogButton);
-                Button ok = (Button) alertDialog.findViewById(R.id.continueGameDialogButton);
-                ok.setOnClickListener(new View.OnClickListener() {
+                TextView dialogTitle = (TextView) alertDialog.findViewById(R.id.gameTitle);
+                TextView dialogDescription = (TextView) alertDialog.findViewById(R.id.gameInfoDescription);
+                dialogTitle.setText(R.string.myth_fact_game);
+                dialogDescription.setText(R.string.myth_fact_description);
+                Button cancelButton = (Button) alertDialog.findViewById(R.id.noGameDialogButton);
+                Button okButton = (Button) alertDialog.findViewById(R.id.continueGameDialogButton);
+                okButton.setOnClickListener(new View.OnClickListener() {
                     @Override
                     public void onClick(View view) {
                         startActivity(new Intent(NewHomeActivity.this, MythFactGame.class));
                         alertDialog.dismiss();
                     }
                 });
-                cancel.setOnClickListener(new View.OnClickListener() {
+                cancelButton.setOnClickListener(new View.OnClickListener() {
                     @Override
                     public void onClick(View view) {
                         alertDialog.dismiss();
@@ -121,8 +121,6 @@ public class NewHomeActivity extends Activity{
 
                 // Showing Alert Message
                 alertDialog.show();
-
-
             }
         };
     }
@@ -136,20 +134,20 @@ public class NewHomeActivity extends Activity{
                 alertDialog.setCancelable(false);
 
                 // Setting Dialog Title
-                TextView title = (TextView) alertDialog.findViewById(R.id.gameTitle);
-                TextView description = (TextView) alertDialog.findViewById(R.id.gameInfoDescription);
-                title.setText(R.string.rapid_fire_game);
-                description.setText(R.string.rapid_fire_description);
-                Button cancel = (Button) alertDialog.findViewById(R.id.noGameDialogButton);
-                Button ok = (Button) alertDialog.findViewById(R.id.continueGameDialogButton);
-                ok.setOnClickListener(new View.OnClickListener() {
+                TextView dialogTitle = (TextView) alertDialog.findViewById(R.id.gameTitle);
+                TextView dialogDescription = (TextView) alertDialog.findViewById(R.id.gameInfoDescription);
+                dialogTitle.setText(R.string.rapid_fire_game);
+                dialogDescription.setText(R.string.rapid_fire_description);
+                Button cancelButton = (Button) alertDialog.findViewById(R.id.noGameDialogButton);
+                Button okButton = (Button) alertDialog.findViewById(R.id.continueGameDialogButton);
+                okButton.setOnClickListener(new View.OnClickListener() {
                     @Override
                     public void onClick(View view) {
                         startActivity(new Intent(NewHomeActivity.this, RapidFireGame.class));
                         alertDialog.dismiss();
                     }
                 });
-                cancel.setOnClickListener(new View.OnClickListener() {
+                cancelButton.setOnClickListener(new View.OnClickListener() {
                     @Override
                     public void onClick(View view) {
                         alertDialog.dismiss();

--- a/malaria-app-android/src/main/java/com/peacecorps/malaria/activities/NewHomeActivity.java
+++ b/malaria-app-android/src/main/java/com/peacecorps/malaria/activities/NewHomeActivity.java
@@ -98,7 +98,6 @@ public class NewHomeActivity extends Activity{
                 alertDialog.setContentView(R.layout.game_info_dialog);
                 alertDialog.setCancelable(false);
 
-                // Setting Dialog Title
                 TextView dialogTitle = (TextView) alertDialog.findViewById(R.id.gameTitle);
                 TextView dialogDescription = (TextView) alertDialog.findViewById(R.id.gameInfoDescription);
                 dialogTitle.setText(R.string.myth_fact_game);
@@ -119,7 +118,6 @@ public class NewHomeActivity extends Activity{
                     }
                 });
 
-                // Showing Alert Message
                 alertDialog.show();
             }
         };
@@ -133,7 +131,6 @@ public class NewHomeActivity extends Activity{
                 alertDialog.setContentView(R.layout.game_info_dialog);
                 alertDialog.setCancelable(false);
 
-                // Setting Dialog Title
                 TextView dialogTitle = (TextView) alertDialog.findViewById(R.id.gameTitle);
                 TextView dialogDescription = (TextView) alertDialog.findViewById(R.id.gameInfoDescription);
                 dialogTitle.setText(R.string.rapid_fire_game);
@@ -154,7 +151,6 @@ public class NewHomeActivity extends Activity{
                     }
                 });
 
-                // Showing Alert Message
                 alertDialog.show();
             }
         };

--- a/malaria-app-android/src/main/java/com/peacecorps/malaria/activities/NewHomeActivity.java
+++ b/malaria-app-android/src/main/java/com/peacecorps/malaria/activities/NewHomeActivity.java
@@ -1,12 +1,12 @@
 package com.peacecorps.malaria.activities;
 
 import android.app.Activity;
-import android.app.AlertDialog;
-import android.content.DialogInterface;
+import android.app.Dialog;
 import android.content.Intent;
 import android.os.Bundle;
 import android.view.View;
 import android.widget.Button;
+import android.widget.TextView;
 
 import com.peacecorps.malaria.R;
 
@@ -94,22 +94,32 @@ public class NewHomeActivity extends Activity{
         return new View.OnClickListener() {
             @Override
             public void onClick(View view) {
-                AlertDialog alertDialog = new AlertDialog.Builder(NewHomeActivity.this).create();
-                alertDialog.setTitle("Myth Fact Game");
-                alertDialog.setMessage("Test your knowledge of Malaria! Drag the facts into the trash if they are a myth, or into the treasure chest if they are a fact. You get one point for each correct answer.");
-                alertDialog.setButton(AlertDialog.BUTTON_POSITIVE, "Play!",
-                        new DialogInterface.OnClickListener() {
-                            public void onClick(DialogInterface dialog, int which) {
-                                dialog.dismiss();
-                                startActivity(new Intent(NewHomeActivity.this, MythFactGame.class));
-                            }
-                        });
-                alertDialog.setButton(AlertDialog.BUTTON_NEGATIVE, "Cancel",
-                        new DialogInterface.OnClickListener() {
-                            public void onClick(DialogInterface dialog, int which) {
-                                dialog.dismiss();
-                        }
-                        });
+                final Dialog alertDialog = new Dialog(NewHomeActivity.this,android.R.style.Theme_DeviceDefault_Dialog_NoActionBar);
+                alertDialog.setContentView(R.layout.game_info_dialog);
+                alertDialog.setCancelable(false);
+
+                // Setting Dialog Title
+                TextView title = (TextView) alertDialog.findViewById(R.id.gameTitle);
+                TextView description = (TextView) alertDialog.findViewById(R.id.gameInfoDescription);
+                title.setText(R.string.myth_fact_game);
+                description.setText(R.string.myth_fact_description);
+                Button cancel = (Button) alertDialog.findViewById(R.id.noGameDialogButton);
+                Button ok = (Button) alertDialog.findViewById(R.id.continueGameDialogButton);
+                ok.setOnClickListener(new View.OnClickListener() {
+                    @Override
+                    public void onClick(View view) {
+                        startActivity(new Intent(NewHomeActivity.this, MythFactGame.class));
+                        alertDialog.dismiss();
+                    }
+                });
+                cancel.setOnClickListener(new View.OnClickListener() {
+                    @Override
+                    public void onClick(View view) {
+                        alertDialog.dismiss();
+                    }
+                });
+
+                // Showing Alert Message
                 alertDialog.show();
 
 
@@ -121,22 +131,32 @@ public class NewHomeActivity extends Activity{
         return new View.OnClickListener() {
             @Override
             public void onClick(View view) {
-                AlertDialog alertDialog = new AlertDialog.Builder(NewHomeActivity.this).create();
-                alertDialog.setTitle("Rapid Fire Game");
-                alertDialog.setMessage("Test your knowledge of Malaria! You have 5 seconds to choose the correct answer to fill in the blank or complete the sentence about malaria. You get one point for each correct answer.");
-                alertDialog.setButton(AlertDialog.BUTTON_POSITIVE, "Play!",
-                        new DialogInterface.OnClickListener() {
-                            public void onClick(DialogInterface dialog, int which) {
-                                dialog.dismiss();
-                                startActivity(new Intent(NewHomeActivity.this, RapidFireGame.class));
-                            }
-                        });
-                alertDialog.setButton(AlertDialog.BUTTON_NEGATIVE, "Cancel",
-                        new DialogInterface.OnClickListener() {
-                            public void onClick(DialogInterface dialog, int which) {
-                                dialog.dismiss();
-                            }
-                        });
+                final Dialog alertDialog = new Dialog(NewHomeActivity.this,android.R.style.Theme_DeviceDefault_Dialog_NoActionBar);
+                alertDialog.setContentView(R.layout.game_info_dialog);
+                alertDialog.setCancelable(false);
+
+                // Setting Dialog Title
+                TextView title = (TextView) alertDialog.findViewById(R.id.gameTitle);
+                TextView description = (TextView) alertDialog.findViewById(R.id.gameInfoDescription);
+                title.setText(R.string.rapid_fire_game);
+                description.setText(R.string.rapid_fire_description);
+                Button cancel = (Button) alertDialog.findViewById(R.id.noGameDialogButton);
+                Button ok = (Button) alertDialog.findViewById(R.id.continueGameDialogButton);
+                ok.setOnClickListener(new View.OnClickListener() {
+                    @Override
+                    public void onClick(View view) {
+                        startActivity(new Intent(NewHomeActivity.this, RapidFireGame.class));
+                        alertDialog.dismiss();
+                    }
+                });
+                cancel.setOnClickListener(new View.OnClickListener() {
+                    @Override
+                    public void onClick(View view) {
+                        alertDialog.dismiss();
+                    }
+                });
+
+                // Showing Alert Message
                 alertDialog.show();
             }
         };

--- a/malaria-app-android/src/main/res/layout/game_info_dialog.xml
+++ b/malaria-app-android/src/main/res/layout/game_info_dialog.xml
@@ -4,21 +4,18 @@
     android:layout_height="wrap_content"
     android:background="@drawable/dialog_background"
     android:id="@+id/dialogGameInfo">
-
-
     <LinearLayout
         android:layout_width="fill_parent"
         android:layout_height="wrap_content"
         android:orientation="vertical">
-
 
         <LinearLayout
             android:layout_width="fill_parent"
             android:layout_height="wrap_content"
             android:orientation="horizontal"
             android:background="@color/lightest_brown">
-
             <TextView
+                android:id="@+id/gameTitle"
                 android:layout_width="fill_parent"
                 android:layout_height="wrap_content"
                 android:gravity="center"
@@ -27,11 +24,7 @@
                 android:layout_marginTop="10dp"
                 android:layout_marginLeft="10dp"
                 android:layout_marginRight="10dp"
-                android:layout_marginBottom="10dp"
-                android:id="@+id/gameTitle"
-                >
-            </TextView>
-
+                android:layout_marginBottom="10dp" />
         </LinearLayout>
 
         <LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
@@ -39,14 +32,13 @@
             android:layout_height="fill_parent"
             android:orientation="vertical"
             android:layout_margin="30dp">
-
             <TextView
+                android:id="@+id/gameInfoDescription"
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
                 android:gravity="center"
                 android:textSize="20sp"
-                android:textColor="@color/golden_brown"
-                android:id="@+id/gameInfoDescription"/>
+                android:textColor="@color/golden_brown" />
         </LinearLayout>
 
         <LinearLayout
@@ -63,27 +55,23 @@
                 android:id="@+id/noGameDialogButton"
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
-                android:text="Back"
+                android:text="@string/back_from_game"
                 android:layout_marginTop="5dp"
                 android:layout_marginRight="10dp"
                 android:layout_marginLeft="5dp"
                 android:background="@drawable/info_hub_button"
-                android:textColor="@color/white"
-                />
+                android:textColor="@color/white"  />
             <Button
                 android:id="@+id/continueGameDialogButton"
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
-                android:text="Start Game"
+                android:text="@string/start_game"
                 android:layout_marginTop="5dp"
                 android:layout_marginRight="10dp"
                 android:layout_marginLeft="5dp"
                 android:background="@drawable/info_hub_button"
-                android:textColor="@color/white"
-                />
-
+                android:textColor="@color/white" />
         </LinearLayout>
 
     </LinearLayout>
-
 </RelativeLayout>

--- a/malaria-app-android/src/main/res/layout/game_info_dialog.xml
+++ b/malaria-app-android/src/main/res/layout/game_info_dialog.xml
@@ -1,0 +1,89 @@
+<?xml version="1.0" encoding="utf-8"?>
+<RelativeLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:layout_width="fill_parent"
+    android:layout_height="wrap_content"
+    android:background="@drawable/dialog_background"
+    android:id="@+id/dialogGameInfo">
+
+
+    <LinearLayout
+        android:layout_width="fill_parent"
+        android:layout_height="wrap_content"
+        android:orientation="vertical">
+
+
+        <LinearLayout
+            android:layout_width="fill_parent"
+            android:layout_height="wrap_content"
+            android:orientation="horizontal"
+            android:background="@color/lightest_brown">
+
+            <TextView
+                android:layout_width="fill_parent"
+                android:layout_height="wrap_content"
+                android:gravity="center"
+                android:textColor="@color/golden_brown"
+                android:textSize="22dp"
+                android:layout_marginTop="10dp"
+                android:layout_marginLeft="10dp"
+                android:layout_marginRight="10dp"
+                android:layout_marginBottom="10dp"
+                android:id="@+id/gameTitle"
+                >
+            </TextView>
+
+        </LinearLayout>
+
+        <LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+            android:layout_width="fill_parent"
+            android:layout_height="fill_parent"
+            android:orientation="vertical"
+            android:layout_margin="30dp">
+
+            <TextView
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:gravity="center"
+                android:textSize="20sp"
+                android:textColor="@color/golden_brown"
+                android:id="@+id/gameInfoDescription"/>
+        </LinearLayout>
+
+        <LinearLayout
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_weight="0.29"
+            android:gravity="center|bottom"
+            android:orientation="horizontal"
+            android:layout_alignParentBottom="true"
+            android:layout_alignParentLeft="true"
+            android:layout_alignParentStart="true"
+            android:layout_marginBottom="5dp">
+            <Button
+                android:id="@+id/noGameDialogButton"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:text="Back"
+                android:layout_marginTop="5dp"
+                android:layout_marginRight="10dp"
+                android:layout_marginLeft="5dp"
+                android:background="@drawable/info_hub_button"
+                android:textColor="@color/white"
+                />
+            <Button
+                android:id="@+id/continueGameDialogButton"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:text="Start Game"
+                android:layout_marginTop="5dp"
+                android:layout_marginRight="10dp"
+                android:layout_marginLeft="5dp"
+                android:background="@drawable/info_hub_button"
+                android:textColor="@color/white"
+                />
+
+        </LinearLayout>
+
+    </LinearLayout>
+
+</RelativeLayout>

--- a/malaria-app-android/src/main/res/values/strings.xml
+++ b/malaria-app-android/src/main/res/values/strings.xml
@@ -37,6 +37,23 @@
     <string name="items_spinner_label">Pick Items</string>
     <string name="trip_select_string">Add Packing Items</string>
     <string name="dump_test">Fetching...</string>
+    <string name="myth_fact_game">Myth Fact Game</string>
+    <string name="rapid_fire_game">Rapid Fire Game</string>
+    <string name="myth_fact_description">
+        - Decide whether the statement is correct or false by dragging to its corresponding container.
+        \n
+        \n
+        - Score achievement points for every correct answer you give.
+        \n
+        \n
+        - The container will reveal whether the answer is right or wrong.
+    </string>
+    <string name="rapid_fire_description">
+        - Answer questions quickly, under time pressure.
+        \n
+        \n
+        - Score achievement points for every correct answer you give.
+    </string>
     <string name="mal_description">
         -Interferes with growth of parasites in red blood cells\n
         -Take the medicine everyday at the same time with food\n

--- a/malaria-app-android/src/main/res/values/strings.xml
+++ b/malaria-app-android/src/main/res/values/strings.xml
@@ -37,6 +37,8 @@
     <string name="items_spinner_label">Pick Items</string>
     <string name="trip_select_string">Add Packing Items</string>
     <string name="dump_test">Fetching...</string>
+    <string name="back_from_game">Back</string>
+    <string name="start_game">Start Game</string>
     <string name="myth_fact_game">Myth Fact Game</string>
     <string name="rapid_fire_game">Rapid Fire Game</string>
     <string name="myth_fact_description">


### PR DESCRIPTION
Added game description dialog before playing the myth fact/rapid fire games. This included editing the NewHomeActivity, adding a new res layout file for such dialogs, and adding to the strings.xml file. Attached are images of the revision.

<img width="338" alt="screen shot 2016-12-03 at 10 35 52 pm" src="https://cloud.githubusercontent.com/assets/16553284/20864519/cf8c96f8-b9a9-11e6-92c1-c949b726f243.png">
<img width="335" alt="screen shot 2016-12-03 at 10 36 01 pm" src="https://cloud.githubusercontent.com/assets/16553284/20864520/cfba8b94-b9a9-11e6-97b0-a8a75bfabc1c.png">

