### PR TITLE
Fixes #148:Myth vs Fact Mini game starts from beginning on orientation change

### DIFF
--- a/malaria-app-android/src/main/AndroidManifest.xml
+++ b/malaria-app-android/src/main/AndroidManifest.xml
@@ -85,7 +85,8 @@
         <activity android:name=".fragment.ThirdAnalyticFragment"/>
         <activity android:name=".activities.DayFragmentActivity"/>
         <activity android:name=".activities.BadgeRoom"/>
-        <activity android:name=".activities.MythFactGame"/>
+        <activity android:name=".activities.MythFactGame"
+            android:configChanges="orientation|screenSize"/>
         <activity android:name=".activities.RapidFireGame"/>
         <activity android:name=".activities.MedicineStore"/>
         <activity android:name=".activities.NewHomeActivity"/>


### PR DESCRIPTION
Fixes issue #148 

**Changes**

![ezgif com-optimize 2](https://cloud.githubusercontent.com/assets/18090596/21698505/45e2ad7e-d3bd-11e6-9cb6-f7e0d9225bcf.gif)


**Fix**
I have used android:configChanges attribute in AndroidManifest file that represents the configuration we want to handle.So basically when the configurations change, MythFactGame activity does not restart thereby preserving the activity state as it was before.