### PR TITLE
Fix Landscape UI issues

### DIFF
--- a/malaria-app-android/src/main/res/layout-land/fragment_first_analytic_screen.xml
+++ b/malaria-app-android/src/main/res/layout-land/fragment_first_analytic_screen.xml
@@ -1,0 +1,148 @@
+<?xml version="1.0" encoding="utf-8"?>
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:layout_gravity="center"
+    android:background="@color/back_ground"
+    android:orientation="vertical"
+    android:padding="@dimen/first_analytic_layout_padding" >
+
+    <ScrollView
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content">
+        <LinearLayout
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:orientation="vertical">
+            <Button
+                android:id="@+id/fragment_first_screen_settings_button"
+                android:layout_width="@dimen/first_analytic_setting_button_width"
+                android:layout_height="@dimen/first_analytic_setting_button_height"
+                android:layout_gravity="end"
+                android:layout_margin="@dimen/first_analytic_setting_button_padding"
+                android:adjustViewBounds="true"
+                android:background="@drawable/settings_normal"
+                android:scaleType="fitCenter" />
+
+            <LinearLayout
+                android:layout_width="wrap_content"
+                android:layout_height="match_parent"
+                android:orientation="vertical"
+                android:gravity="center_horizontal"
+                android:layout_gravity="center_horizontal">
+
+                <LinearLayout
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:layout_gravity="left"
+                    android:orientation="horizontal"
+                    android:padding="@dimen/first_analytic_row_padding" >
+
+                    <ImageView
+                        android:layout_width="@dimen/first_analytic_row_imageview_width"
+                        android:layout_height="@dimen/first_analytic_row_imageview_height"
+                        android:adjustViewBounds="true"
+                        android:background="@drawable/medication_last_normal"
+                        android:scaleType="fitCenter" />
+
+                    <TextView
+                        android:layout_width="wrap_content"
+                        android:layout_height="wrap_content"
+                        android:layout_gravity="center_vertical"
+                        android:paddingLeft="@dimen/first_analytic_row_textview_paddingeft"
+                        android:paddingRight="@dimen/first_analytic_row_textview_paddingRight"
+                        android:text="@string/first_analytic_screen_medicine_last_taken_text"
+                        android:textSize="@dimen/first_analytic_textSize"
+                        android:textColor="@color/golden_brown"
+                        android:id="@+id/mlt"
+                        />
+
+                    <TextView android:layout_width="match_parent"
+                        android:layout_height="wrap_content"
+                        android:id="@+id/checkMediLastTakenTime"
+                        android:text="15/07"
+                        android:background="@drawable/info_hub_button"
+                        android:textColor="@color/white"
+                        android:textSize="@dimen/first_analytic_value_textSize"
+                        android:layout_gravity="center_vertical"
+                        />
+                    />
+                </LinearLayout>
+
+                <LinearLayout
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:layout_gravity="left"
+                    android:orientation="horizontal"
+                    android:padding="@dimen/first_analytic_row_padding" >
+
+                    <ImageView
+                        android:layout_width="@dimen/first_analytic_row_imageview_width"
+                        android:layout_height="@dimen/first_analytic_row_imageview_height"
+                        android:adjustViewBounds="true"
+                        android:background="@drawable/doses_missing_image_normal"
+                        android:scaleType="fitCenter" />
+
+                    <TextView
+                        android:layout_width="wrap_content"
+                        android:layout_height="wrap_content"
+                        android:layout_gravity="center_vertical"
+                        android:paddingLeft="@dimen/first_analytic_row_textview_paddingeft"
+                        android:paddingRight="@dimen/first_analytic_row_textview_paddingRight"
+                        android:text="@string/first_analytic_screen_doses_missing_text"
+                        android:textSize="@dimen/first_analytic_textSize"
+                        android:textColor="@color/golden_brown"
+                        android:id="@+id/dinr"
+                        />
+
+                    <TextView
+                        android:id="@+id/doses"
+                        android:layout_width="match_parent"
+                        android:layout_height="wrap_content"
+                        android:background="@drawable/info_hub_button"
+                        android:textColor="@color/white"
+                        android:textSize="@dimen/first_analytic_value_textSize"
+                        android:layout_gravity="center_vertical"
+                        />
+                </LinearLayout>
+
+                <LinearLayout
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:layout_gravity="left"
+                    android:orientation="horizontal"
+                    android:padding="@dimen/first_analytic_row_padding" >
+
+                    <ImageView
+                        android:layout_width="@dimen/first_analytic_row_imageview_width"
+                        android:layout_height="@dimen/first_analytic_row_imageview_height"
+                        android:adjustViewBounds="true"
+                        android:background="@drawable/medicine_adhere_normal"
+                        android:scaleType="fitCenter" />
+
+                    <TextView
+                        android:layout_width="wrap_content"
+                        android:layout_height="wrap_content"
+                        android:layout_gravity="center_vertical"
+                        android:paddingLeft="@dimen/first_analytic_row_textview_paddingeft"
+                        android:paddingRight="@dimen/first_analytic_row_textview_paddingRight"
+                        android:text="@string/first_analytic_screen_medicine_adherence_to_medicine_text"
+                        android:textSize="@dimen/first_analytic_textSize"
+                        android:textColor="@color/golden_brown"
+                        android:id="@+id/atm"
+                        />
+
+                    <TextView
+                        android:id="@+id/adherence"
+                        android:layout_width="match_parent"
+                        android:layout_height="wrap_content"
+                        android:background="@drawable/info_hub_button"
+                        android:textColor="@color/white"
+                        android:textSize="@dimen/first_analytic_value_textSize"
+                        android:layout_gravity="center_vertical" />
+
+                </LinearLayout>
+            </LinearLayout>
+        </LinearLayout>
+    </ScrollView>
+</LinearLayout>

--- a/malaria-app-android/src/main/res/layout-land/myth_fact_game.xml
+++ b/malaria-app-android/src/main/res/layout-land/myth_fact_game.xml
@@ -8,7 +8,7 @@
     <LinearLayout
         android:layout_width="match_parent"
         android:layout_height="0dp"
-        android:layout_weight="1.5"
+        android:layout_weight="1.6"
         android:orientation="vertical">
         <LinearLayout
             android:layout_width="match_parent"
@@ -16,7 +16,7 @@
             android:gravity="center_vertical">
             <Button
                 android:layout_width="0dp"
-                android:layout_height="40dp"
+                android:layout_height="@dimen/myth_game_exit_button_height"
                 android:id="@+id/exitBtn"
                 android:layout_gravity="right"
                 android:layout_weight="0.4"
@@ -39,7 +39,7 @@
 
             <Button
                 android:layout_width="0dp"
-                android:layout_height="40dp"
+                android:layout_height="@dimen/myth_game_next_button_height"
                 android:id="@+id/nextBtn"
                 android:layout_weight="0.4"
                 android:background="@drawable/info_hub_button"

--- a/malaria-app-android/src/main/res/layout/fragment_first_analytic_screen.xml
+++ b/malaria-app-android/src/main/res/layout/fragment_first_analytic_screen.xml
@@ -5,7 +5,7 @@
               android:layout_gravity="center"
               android:background="@color/back_ground"
               android:orientation="vertical"
-              android:padding="2dp" >
+              android:padding="@dimen/first_analytic_layout_padding" >
 
  <ScrollView
      android:layout_width="match_parent"
@@ -16,10 +16,10 @@
          android:orientation="vertical">
          <Button
              android:id="@+id/fragment_first_screen_settings_button"
-             android:layout_width="24dp"
-             android:layout_height="24dp"
+             android:layout_width="@dimen/first_analytic_setting_button_width"
+             android:layout_height="@dimen/first_analytic_setting_button_height"
              android:layout_gravity="end"
-             android:layout_margin="5dp"
+             android:layout_margin="@dimen/first_analytic_setting_button_padding"
              android:adjustViewBounds="true"
              android:background="@drawable/settings_normal"
              android:scaleType="fitCenter" />
@@ -29,11 +29,11 @@
              android:layout_height="wrap_content"
              android:layout_gravity="left"
              android:orientation="horizontal"
-             android:padding="5dp" >
+             android:padding="@dimen/first_analytic_row_padding" >
 
              <ImageView
-                 android:layout_width="70dp"
-                 android:layout_height="60dp"
+                 android:layout_width="@dimen/first_analytic_row_imageview_width"
+                 android:layout_height="@dimen/first_analytic_row_imageview_height"
                  android:adjustViewBounds="true"
                  android:background="@drawable/medication_last_normal"
                  android:scaleType="fitCenter" 
@@ -43,10 +43,10 @@
                  android:layout_width="wrap_content"
                  android:layout_height="wrap_content"
                  android:layout_gravity="center_vertical"
-                 android:paddingLeft="3dp"
-                 android:paddingRight="3dp"
+                 android:paddingLeft="@dimen/first_analytic_row_textview_paddingeft"
+                 android:paddingRight="@dimen/first_analytic_row_textview_paddingRight"
                  android:text="@string/first_analytic_screen_medicine_last_taken_text"
-                 android:textSize="18sp"
+                 android:textSize="@dimen/first_analytic_textSize"
                  android:textColor="@color/golden_brown"
                  android:id="@+id/mlt"
                  />
@@ -57,11 +57,9 @@
                  android:text="15/07"
                  android:background="@drawable/info_hub_button"
                  android:textColor="@color/white"
-                 android:textSize="17sp"
+                 android:textSize="@dimen/first_analytic_value_textSize"
                  android:layout_gravity="center_vertical"
-
                  />
-
              />
 
          </LinearLayout>
@@ -71,11 +69,11 @@
              android:layout_height="wrap_content"
              android:layout_gravity="left"
              android:orientation="horizontal"
-             android:padding="5dp" >
+             android:padding="@dimen/first_analytic_row_padding" >
 
              <ImageView
-                 android:layout_width="70dp"
-                 android:layout_height="60dp"
+                 android:layout_width="@dimen/first_analytic_row_imageview_width"
+                 android:layout_height="@dimen/first_analytic_row_imageview_height"
                  android:adjustViewBounds="true"
                  android:background="@drawable/doses_missing_image_normal"
                  android:scaleType="fitCenter"
@@ -85,10 +83,10 @@
                  android:layout_width="wrap_content"
                  android:layout_height="wrap_content"
                  android:layout_gravity="center_vertical"
-                 android:paddingLeft="3dp"
-                 android:paddingRight="3dp"
+                 android:paddingLeft="@dimen/first_analytic_row_textview_paddingeft"
+                 android:paddingRight="@dimen/first_analytic_row_textview_paddingRight"
                  android:text="@string/first_analytic_screen_doses_missing_text"
-                 android:textSize="18sp"
+                 android:textSize="@dimen/first_analytic_textSize"
                  android:textColor="@color/golden_brown"
                  android:id="@+id/dinr"
                  />
@@ -99,7 +97,7 @@
                  android:layout_height="wrap_content"
                  android:background="@drawable/info_hub_button"
                  android:textColor="@color/white"
-                 android:textSize="17sp"
+                 android:textSize="@dimen/first_analytic_value_textSize"
                  android:layout_gravity="center_vertical"
                  />
 
@@ -110,11 +108,11 @@
              android:layout_height="wrap_content"
              android:layout_gravity="left"
              android:orientation="horizontal"
-             android:padding="5dp" >
+             android:padding="@dimen/first_analytic_row_padding" >
 
              <ImageView
-                 android:layout_width="70dp"
-                 android:layout_height="60dp"
+                 android:layout_width="@dimen/first_analytic_row_imageview_width"
+                 android:layout_height="@dimen/first_analytic_row_imageview_height"
                  android:adjustViewBounds="true"
                  android:background="@drawable/medicine_adhere_normal"
                  android:scaleType="fitCenter" 
@@ -124,10 +122,10 @@
                  android:layout_width="wrap_content"
                  android:layout_height="wrap_content"
                  android:layout_gravity="center_vertical"
-                 android:paddingLeft="3dp"
-                 android:paddingRight="3dp"
+                 android:paddingLeft="@dimen/first_analytic_row_textview_paddingeft"
+                 android:paddingRight="@dimen/first_analytic_row_textview_paddingRight"
                  android:text="@string/first_analytic_screen_medicine_adherence_to_medicine_text"
-                 android:textSize="18sp"
+                 android:textSize="@dimen/first_analytic_textSize"
                  android:textColor="@color/golden_brown"
                  android:id="@+id/atm"
                  />
@@ -138,7 +136,7 @@
                  android:layout_height="wrap_content"
                  android:background="@drawable/info_hub_button"
                  android:textColor="@color/white"
-                 android:textSize="17sp"
+                 android:textSize="@dimen/first_analytic_value_textSize"
                  android:layout_gravity="center_vertical" />
 
          </LinearLayout>

--- a/malaria-app-android/src/main/res/layout/fragment_user_medicine_settings.xml
+++ b/malaria-app-android/src/main/res/layout/fragment_user_medicine_settings.xml
@@ -114,8 +114,8 @@
                 android:background="@color/gray"
                 android:hint="@string/user_medicine_settings_activity_done_button"
                 android:textColorHint="@color/white"
-            />
-
+                android:layout_marginBottom="@dimen/user_medicine_settings_marginBottom"
+                />
         </LinearLayout>
 
     </ScrollView>

--- a/malaria-app-android/src/main/res/values/dimens.xml
+++ b/malaria-app-android/src/main/res/values/dimens.xml
@@ -3,5 +3,19 @@
     <!-- Default screen margins, per the Android Design guidelines. -->
     <dimen name="activity_horizontal_margin">16dp</dimen>
     <dimen name="activity_vertical_margin">16dp</dimen>
+    <dimen name="user_medicine_settings_marginBottom">15dp</dimen>
+    <dimen name="myth_game_exit_button_height">38dp</dimen>
+    <dimen name="myth_game_next_button_height">38dp</dimen>
+    <dimen name="first_analytic_layout_padding">2dp</dimen>
+    <dimen name="first_analytic_setting_button_width">24dp</dimen>
+    <dimen name="first_analytic_setting_button_height">24dp</dimen>
+    <dimen name="first_analytic_setting_button_padding">5dp</dimen>
+    <dimen name="first_analytic_row_padding">5dp</dimen>
+    <dimen name="first_analytic_row_imageview_width">70dp</dimen>
+    <dimen name="first_analytic_row_imageview_height">60dp</dimen>
+    <dimen name="first_analytic_row_textview_paddingeft">3dp</dimen>
+    <dimen name="first_analytic_row_textview_paddingRight">3dp</dimen>
+    <dimen name="first_analytic_textSize">18sp</dimen>
+    <dimen name="first_analytic_value_textSize">17sp</dimen>
 
 </resources>


### PR DESCRIPTION
#196 
The landscape UI issues in Myth Fact Game, First Analytics screen and Medicine Settings screen have been fixed as shown -

<img src="https://cloud.githubusercontent.com/assets/13872065/21898460/f8006352-d912-11e6-97d6-a25d26a57b69.jpeg" height="220" width="320"> <img src="https://cloud.githubusercontent.com/assets/13872065/22180379/931fca16-e094-11e6-97ba-7b02ab30b67d.jpeg" height="220" width="320">

<img src="https://cloud.githubusercontent.com/assets/13872065/21898518/1738732c-d913-11e6-92b2-f0b4b5fd81d0.jpeg" height="220" width="320"> <img src="https://cloud.githubusercontent.com/assets/13872065/22180377/931f1ddc-e094-11e6-8ba4-a2244bb8f19d.jpeg" height="220" width="320">

<img src="https://cloud.githubusercontent.com/assets/13872065/21898472/fd5cce26-d912-11e6-8482-0215188b27b2.jpeg" height="220" width="320"> <img src="https://cloud.githubusercontent.com/assets/13872065/22180378/931f24a8-e094-11e6-9ef5-a117ca63e327.jpeg" height="220" width="320"> 

For FirstAnalyticScreen, a new file for landscape version is created as gravity center was creating problems with portrait mode and hence a new file was needed for landscape.