### PR TITLE
DatePicker previous dates disabled.

### DIFF
--- a/malaria-app-android/src/main/java/com/peacecorps/malaria/activities/TripIndicatorFragmentActivity.java
+++ b/malaria-app-android/src/main/java/com/peacecorps/malaria/activities/TripIndicatorFragmentActivity.java
@@ -77,6 +77,7 @@ public class TripIndicatorFragmentActivity extends FragmentActivity {
     private TextView pmtLabel;
     SharedPreferences preferences;
     SharedPreferences.Editor editor;
+    public Calendar departureDate;
 
     public static TripIndicatorFragmentActivity instance(){
         return inst;
@@ -503,7 +504,7 @@ public class TripIndicatorFragmentActivity extends FragmentActivity {
                 SharedPreferenceStore.mEditor.clear().commit();
                 startActivity(new Intent(getApplication().getApplicationContext(),
                         UserMedicineSettingsFragmentActivity.class));
-
+                dialog.dismiss();
             }
         });
 
@@ -590,13 +591,16 @@ public class TripIndicatorFragmentActivity extends FragmentActivity {
         @Override
         public Dialog onCreateDialog(Bundle savedInstanceState) {
             // Use the current date as the default date in the picker
-            final Calendar c = Calendar.getInstance();
+            final Calendar c = departureDate;
+            c.add(Calendar.DATE, 1);
             int year = c.get(Calendar.YEAR);
             int month = c.get(Calendar.MONTH);
             int day = c.get(Calendar.DAY_OF_MONTH);
 
             // Create a new instance of DatePickerDialog and return it
-            return new DatePickerDialog(getActivity(), R.style.MyDatePicker , this, year, month, day);
+            DatePickerDialog datePickerDialog = new DatePickerDialog(getActivity(), R.style.MyDatePicker , this, year, month, day);
+            datePickerDialog.getDatePicker().setMinDate(c.getTimeInMillis());
+            return datePickerDialog;
         }
 
         public void onDateSet(DatePicker view, int year, int month, int day) {
@@ -627,6 +631,10 @@ public class TripIndicatorFragmentActivity extends FragmentActivity {
     }
 
     public void showDatePickerDialogArrival(View v) {
+        if(!depar){
+            Toast.makeText(getApplicationContext(), "Set departure date first.", Toast.LENGTH_SHORT).show();
+            return;
+        }
         DialogFragment newFragment = new DatePickerFragmentArrival();
         newFragment.show(getFragmentManager(), "Arrival Data");
     }
@@ -638,16 +646,21 @@ public class TripIndicatorFragmentActivity extends FragmentActivity {
         public Dialog onCreateDialog(Bundle savedInstanceState) {
             // Use the current date as the default date in the picker
             final Calendar c = Calendar.getInstance();
-             dep_year = c.get(Calendar.YEAR);
-             dep_month = c.get(Calendar.MONTH);
-             dep_day = c.get(Calendar.DAY_OF_MONTH);
+            c.add(Calendar.DATE, 1);
+            dep_year = c.get(Calendar.YEAR);
+            dep_month = c.get(Calendar.MONTH);
+            dep_day = c.get(Calendar.DAY_OF_MONTH);
 
             // Create a new instance of DatePickerDialog and return it
-            return new DatePickerDialog(getActivity(),R.style.MyDatePicker ,this, dep_year, dep_month, dep_day);
+            DatePickerDialog datePickerDialog = new DatePickerDialog(getActivity(), R.style.MyDatePicker , this, dep_year, dep_month, dep_day);
+            datePickerDialog.getDatePicker().setMinDate(c.getTimeInMillis());
+            return datePickerDialog;
         }
 
         public void onDateSet(DatePicker view, int year, int month, int day) {
             setTextFields(day,month+1,year);
+            departureDate = Calendar.getInstance();
+            departureDate.set(year, month, day);
 
             depar=true;
 


### PR DESCRIPTION
Solves issue #217 

Changes I have made - 
Departure date can be any date starting tomorrow. (Today's date and previous dates are disabled.)
Arrival date must be at least one day after the departure date. (All dates until one day after departure date disabled.)
I have included screen shots as well 
1. Departure date
![dep](https://cloud.githubusercontent.com/assets/17262180/22408273/938add5c-e69c-11e6-9274-7a5d56076bba.png)
2. Arrival date
![arr](https://cloud.githubusercontent.com/assets/17262180/22408281/b1584c16-e69c-11e6-9c4b-e71082c44dae.png)

@chhavip @yatna @anubhakushwaha 
please review the PR