### PR TITLE
Fixes #240 : Adjusted Icons to Match the Text's layout in Spinner

### DIFF
--- a/malaria-app-android/src/main/res/layout/trip_drug_info.xml
+++ b/malaria-app-android/src/main/res/layout/trip_drug_info.xml
@@ -7,7 +7,8 @@
             android:id="@+id/infoDrug"
             android:layout_width="20dp"
             android:layout_height="20dp"
-            android:layout_marginTop="10dp"
+            android:layout_marginTop="4dp"
+            android:layout_marginLeft="4dp"
             android:background="@drawable/info_hub_normal"
             android:focusable="false"/>
 


### PR DESCRIPTION
 ![](https://cloud.githubusercontent.com/assets/16818129/23811729/409b3076-05fd-11e7-9801-00b1b2e7bb94.png)

@anubhakushwaha 
Ref #245 