### PR TITLE
Fixes#140:Removing Viewpager External Dependency

### DIFF
--- a/malaria-app-android/build.gradle
+++ b/malaria-app-android/build.gradle
@@ -31,7 +31,6 @@ android {
 
 dependencies {
     compile 'com.android.support:support-v4:22+' // v4
-    compile 'com.viewpagerindicator:library:2.4.1@aar'
     compile files('libs/volleylib.jar')
     compile files('libs/GraphView-3.1.2.jar')
     testCompile 'junit:junit:4.12'

--- a/malaria-app-android/src/main/java/com/peacecorps/malaria/activities/MainActivity.java
+++ b/malaria-app-android/src/main/java/com/peacecorps/malaria/activities/MainActivity.java
@@ -9,36 +9,40 @@ import android.support.v4.app.FragmentActivity;
 import android.support.v4.view.ViewPager;
 import android.support.v4.view.ViewPager.OnPageChangeListener;
 
+import android.text.Html;
 import android.util.Log;
 import android.view.View;
 import android.widget.Button;
+import android.widget.LinearLayout;
+import android.widget.TextView;
 
 import com.peacecorps.malaria.R;
 import com.peacecorps.malaria.model.SharedPreferenceStore;
 import com.peacecorps.malaria.adapter.FragmentAdapter;
 import com.peacecorps.malaria.db.DatabaseSQLiteHelper;
 import com.peacecorps.malaria.fragment.FirstAnalyticFragment;
-import com.viewpagerindicator.CirclePageIndicator;
-import com.viewpagerindicator.PageIndicator;
+
+
 
 public class MainActivity extends FragmentActivity {
 
 
     FragmentAdapter mAdapter;
     ViewPager mPager;
-    PageIndicator mIndicator;
     Button mInfoButton;
     Button mTripButton;
     Button tempButton;
     Button userProfile;
     String TAGMA="MainActivity";
+    private LinearLayout indicatingDotsContainer;
+    private TextView[] dots;
 
 
     @Override
     public void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
         setContentView(R.layout.activity_main);
-
+        addDots(0);
         final DatabaseSQLiteHelper sqLite = new DatabaseSQLiteHelper(this);
         /*Method opens the Info Hub
         *Tiny 'i' symbol in the Setup Screen is Info Hub Button
@@ -49,6 +53,7 @@ public class MainActivity extends FragmentActivity {
             public void onClick(View v) {
                 startActivity(new Intent(getApplication().getApplicationContext(), InfoHubFragmentActivity.class));
                 finish();
+
 
             }
         });
@@ -92,11 +97,11 @@ public class MainActivity extends FragmentActivity {
         mPager = (ViewPager) findViewById(R.id.vPager);
         mPager.setAdapter(mAdapter);
         Log.d(TAGMA, "Adapter Set");
-        mIndicator = (CirclePageIndicator) findViewById(R.id.vIndicator);
-        mIndicator.setViewPager(mPager);
-        mIndicator.setOnPageChangeListener(new OnPageChangeListener() {
+        mPager.setOnPageChangeListener(new OnPageChangeListener() {
+            @Override
+            public void onPageScrolled(int position, float positionOffset, int positionOffsetPixels) {
 
-
+            }
 
             @Override
             public void onPageSelected(int position) {
@@ -105,6 +110,8 @@ public class MainActivity extends FragmentActivity {
                  * Doses in A Row
                  * Adherence
                  * **/
+                addDots(position);
+
                 if (position == 1) {
 
                     Log.d(TAGMA,"Keeping Date");
@@ -151,19 +158,38 @@ public class MainActivity extends FragmentActivity {
             }
 
             @Override
-            public void onPageScrollStateChanged(int i) {
+            public void onPageScrollStateChanged(int state) {
 
             }
-
-            @Override
-            public void onPageScrolled(int i, float v, int i2) {
-
-            }
-
 
         });
 
+
     }
+
+    public void addDots(int position){
+        indicatingDotsContainer = (LinearLayout) findViewById(R.id.layoutDots);
+        dots = new TextView[3];
+        int dot_colorActive = getResources().getColor(R.color.selected_dot);
+        int dot_colorInActive = getResources().getColor(R.color.dot_dark_screen1);
+        indicatingDotsContainer.removeAllViews();
+
+        //number of dots added to container equals number of slides
+        for (int i = 0; i < dots.length; i++) {
+            dots[i] = new TextView(MainActivity.this);
+            dots[i].setText(Html.fromHtml("&#8226;"));
+            dots[i].setTextSize(35);
+            dots[i].setTextColor(dot_colorInActive);
+            indicatingDotsContainer.addView(dots[i]);
+        }
+
+        //dot corresponding to current slide is given active color i.e white color
+        if (dots.length > 0) {
+            dots[position].setTextColor(dot_colorActive);
+        }
+
+    }
+
     /*Calculating Interval between two time*/
     public long checkDrugTakenTimeInterval(String time) {
 

--- a/malaria-app-android/src/main/java/com/peacecorps/malaria/adapter/FragmentAdapter.java
+++ b/malaria-app-android/src/main/java/com/peacecorps/malaria/adapter/FragmentAdapter.java
@@ -3,7 +3,6 @@ package com.peacecorps.malaria.adapter;
 import com.peacecorps.malaria.fragment.HomeScreenFragment;
 import com.peacecorps.malaria.fragment.SecondAnalyticFragment;
 import com.peacecorps.malaria.fragment.FirstAnalyticFragment;
-import com.viewpagerindicator.IconPagerAdapter;
 
 import android.support.v4.app.Fragment;
 import android.support.v4.app.FragmentManager;
@@ -11,18 +10,11 @@ import android.support.v4.app.FragmentStatePagerAdapter;
 
 /**Usd for creating sliding Fragment Screen after the the Home Screen**/
 
-public class FragmentAdapter extends FragmentStatePagerAdapter implements
-        IconPagerAdapter {
+public class FragmentAdapter extends FragmentStatePagerAdapter {
 
     public FragmentAdapter(FragmentManager fm) {
         super(fm);
 
-    }
-
-    @Override
-    public int getIconResId(int index) {
-
-        return 0;
     }
 
     @Override

--- a/malaria-app-android/src/main/res/layout-land/activity_main.xml
+++ b/malaria-app-android/src/main/res/layout-land/activity_main.xml
@@ -20,20 +20,14 @@
         />
 
 
-    <com.viewpagerindicator.CirclePageIndicator
-
-        android:id="@+id/vIndicator"
-        android:padding="5dip"
-        android:layout_height="wrap_content"
+    <LinearLayout
+        android:id="@+id/layoutDots"
         android:layout_width="match_parent"
-        android:textColor="#2FB3E3"
-
-        app:footerLineHeight="1dp"
-        app:footerIndicatorHeight="3dp"
-        app:footerIndicatorStyle="underline"
-        app:selectedColor="#FFFFFF"
-        app:selectedBold="true"
-        />
+        android:layout_height="40dp"
+        android:layout_alignParentBottom="true"
+        android:layout_marginBottom="5dp"
+        android:gravity="center"
+        android:orientation="horizontal"></LinearLayout>
 
 
 

--- a/malaria-app-android/src/main/res/layout/activity_main.xml
+++ b/malaria-app-android/src/main/res/layout/activity_main.xml
@@ -20,20 +20,14 @@
         />
 
 
-    <com.viewpagerindicator.CirclePageIndicator
-
-        android:id="@+id/vIndicator"
-        android:padding="10dip"
-        android:layout_height="wrap_content"
+    <LinearLayout
+        android:id="@+id/layoutDots"
         android:layout_width="match_parent"
-        android:textColor="#2FB3E3"
-
-        app:footerLineHeight="1dp"
-        app:footerIndicatorHeight="3dp"
-        app:footerIndicatorStyle="underline"
-        app:selectedColor="#FFFFFF"
-        app:selectedBold="true"
-        />
+        android:layout_height="40dp"
+        android:layout_alignParentBottom="true"
+        android:layout_marginBottom="5dp"
+        android:gravity="center"
+        android:orientation="horizontal"></LinearLayout>
 
 
 

--- a/malaria-app-android/src/main/res/values/color.xml
+++ b/malaria-app-android/src/main/res/values/color.xml
@@ -32,5 +32,20 @@
     <color name="transparent">#00FFFFFF</color>
     <color name="back_ground">#efdcab</color>
     <color name="calendar_bg_orange">#F19A2D</color>
+    <color name="selected_dot">#ffffff</color>
+
+    <!-- dots inactive colors -->
+    <color name="dot_dark_screen1">#B58B61</color>
+    <color name="dot_dark_screen2">#007A85</color>
+    <color name="dot_dark_screen3">#4658A0</color>
+    <color name="dot_dark_screen4">#32863A</color>
+    <!-- array inactive -->
+    <array name="array_dot_inactive">
+        <item>@color/dot_dark_screen1</item>
+        <item>@color/dot_dark_screen2</item>
+        <item>@color/dot_dark_screen3</item>
+        <item>@color/dot_dark_screen4</item>
+    </array>
+>>>>>>> Fixes#140:Removing Viewpager External Dependency
 
 </resources>


### PR DESCRIPTION
Fixes #140 

External View Pager dependency `compile 'com.viewpagerindicator:library:2.4.1@aar'` has been removed thereby maintaining the entire code base. 
Also, the dots color is now visible while swiping the page that was not in contrast and less visible earlier.
**GIF**
![ezgif com-video-to-gif 11](https://cloud.githubusercontent.com/assets/18090596/24032577/cc5bdbae-0b0e-11e7-9712-44aff9f914df.gif)

@anubhakushwaha @chhavip @yatna Please review this PR. :)
_Thank You_

